### PR TITLE
fix: .zshrc の Zinit チェック統合と compinit 追加

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -37,8 +37,10 @@ setopt HIST_IGNORE_SPACE
 ZINIT_HOME="$HOME/.local/share/zinit/zinit.git"
 if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
     source "$ZINIT_HOME/zinit.zsh"
-    autoload -Uz _zinit
-    (( ${+_comps} )) && _comps[zinit]=_zinit
+fi
+
+# zinit 関数が正常に定義されている場合のみプラグインを読み込む
+if (( $+functions[zinit] )); then
 
     # Powerlevel10k テーマ
     zinit ice depth=1; zinit light romkatv/powerlevel10k
@@ -52,6 +54,10 @@ if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
     autoload -Uz compinit
     zicompinit
 
+    # zinit の補完を登録（compinit 後に行う必要がある）
+    autoload -Uz _zinit
+    compdef _zinit zinit
+
     # オートサジェスチョン (compinit より後に読み込む)
     zinit light zsh-users/zsh-autosuggestions
     # 複数単語での履歴検索
@@ -59,7 +65,10 @@ if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
     # シンタックスハイライト (最後尾での読み込みが推奨)
     zinit light zsh-users/zsh-syntax-highlighting
 else
-    print -P "%F{160}Zinit が見つかりません。セットアップスクリプトを実行してください。%f"
+    print -P "%F{160}Zinit が見つからない、または読み込みに失敗しました。セットアップスクリプトを確認してください。%f"
+    # Zinit が使えなくても標準の補完システムだけは初期化しておく
+    autoload -Uz compinit
+    compinit
 fi
 
 # ----------------------------

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -30,22 +30,13 @@ setopt HIST_SAVE_NO_DUPS
 
 
 # ----------------------------
-# Zinit (プラグインマネージャー) の読み込み
+# Zinit (プラグインマネージャー) の読み込みとプラグイン設定
 # ----------------------------
-# Zinit スクリプトを source (setup.sh または手動でインストールされている前提)
-if [[ -f "$HOME/.local/share/zinit/zinit.git/zinit.zsh" ]]; then
-    source "$HOME/.local/share/zinit/zinit.git/zinit.zsh"
+ZINIT_HOME="$HOME/.local/share/zinit/zinit.git"
+if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
+    source "$ZINIT_HOME/zinit.zsh"
     autoload -Uz _zinit
     (( ${+_comps} )) && _comps[zinit]=_zinit
-else
-    print -P "%F{160}Zinit が見つかりません。セットアップスクリプトを実行するか、手動でインストールしてください。%f"
-fi
-
-# ----------------------------
-# Zinit プラグイン (Zinit経由で読み込み)
-# ----------------------------
-# zinit 関数が存在するか確認してから使用
-if command -v zinit &> /dev/null; then
 
     # Powerlevel10k テーマ
     zinit ice depth=1; zinit light romkatv/powerlevel10k
@@ -61,8 +52,11 @@ if command -v zinit &> /dev/null; then
     # 複数単語での履歴検索
     zinit load zdharma-continuum/history-search-multi-word
 
+    # 補完システムの初期化
+    autoload -Uz compinit
+    compinit
 else
-    print -P "%F{160}zinit コマンドが利用できないため、Zinit プラグインを読み込めません。%f"
+    print -P "%F{160}Zinit が見つかりません。セットアップスクリプトを実行してください。%f"
 fi
 
 # ----------------------------

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -27,6 +27,8 @@ setopt INC_APPEND_HISTORY SHARE_HISTORY
 setopt HIST_IGNORE_ALL_DUPS
 # 履歴保存時に重複を削除し、最新のタイムスタンプのものを残す
 setopt HIST_SAVE_NO_DUPS
+# スペース始まりのコマンドを履歴に残さない（機密情報の漏洩防止）
+setopt HIST_IGNORE_SPACE
 
 
 # ----------------------------
@@ -43,18 +45,19 @@ if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
     # Powerlevel10k ユーザー設定ファイルが存在すれば source
     [[ ! -f "${ZDOTDIR:-$HOME}/.zsh/.p10k.zsh" ]] || source "${ZDOTDIR:-$HOME}/.zsh/.p10k.zsh"
 
-    # シンタックスハイライト
-    zinit light zsh-users/zsh-syntax-highlighting
-    # オートサジェスチョン (入力補完)
-    zinit light zsh-users/zsh-autosuggestions
-    # コンプリーション (補完機能強化)
+    # コンプリーション (fpathに追加するため compinit より前に読み込む)
     zinit light zsh-users/zsh-completions
+
+    # 補完システムの初期化（Zinit のキャッシュ最適化版を使用）
+    autoload -Uz compinit
+    zicompinit
+
+    # オートサジェスチョン (compinit より後に読み込む)
+    zinit light zsh-users/zsh-autosuggestions
     # 複数単語での履歴検索
     zinit load zdharma-continuum/history-search-multi-word
-
-    # 補完システムの初期化
-    autoload -Uz compinit
-    compinit
+    # シンタックスハイライト (最後尾での読み込みが推奨)
+    zinit light zsh-users/zsh-syntax-highlighting
 else
     print -P "%F{160}Zinit が見つかりません。セットアップスクリプトを実行してください。%f"
 fi


### PR DESCRIPTION
## 変更の概要

`.zshrc` の Zinit 関連処理を改善しました。

- Zinit の存在チェックが2箇所（`zinit.zsh` のファイル確認 + `command -v zinit`）に分かれていたのを1つの `if` ブロックに統合
- `ZINIT_HOME` 変数でパスを一元管理
- プラグインの読み込み順序を最適化（`zsh-completions` → `zicompinit` → `zsh-autosuggestions` → `zsh-syntax-highlighting`）
- `compinit` を Zinit のキャッシュ最適化版 `zicompinit` に変更（起動高速化）
- `HIST_IGNORE_SPACE` を追加（スペース始まりのコマンドを履歴に残さずセキュリティ向上）

## 変更の目的

- 2重チェックによるエラーメッセージ重複を防止
- `zsh-completions` の補完定義がタブ補完に反映されるようにする
- 各プラグイン公式が推奨する読み込み順序に準拠し、潜在的な不具合を防止

## 関連Issue
- Close #4