### PR TITLE
feat: setup.sh の機能拡充（前提チェック・設定ファイル配置・コメント修正）

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -8,17 +8,10 @@ fi
 # ----------------------------
 # zsh_history (コマンド履歴)
 # ----------------------------
-# Zsh履歴ファイルのディレクトリ
-_zsh_history_dir=~/.zsh
-
-# ディレクトリが存在しない場合に作成
-if [[ ! -d "$_zsh_history_dir" ]]; then
-    mkdir -p "$_zsh_history_dir"
-    chmod 700 "$_zsh_history_dir" # パーミッションを設定
-fi
-
-# 履歴設定
-HISTFILE=$_zsh_history_dir/.zsh_history
+# 履歴設定（~/.zsh ディレクトリは setup.sh で作成済みの前提）
+HISTFILE=~/.zsh/.zsh_history
+# フェールセーフ: ディレクトリが存在しなければ作成
+[[ -d "${HISTFILE:h}" ]] || mkdir -p "${HISTFILE:h}"
 export HISTSIZE=10000
 export SAVEHIST=50000
 # セッション間で履歴を即時共有

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -11,7 +11,7 @@ fi
 # 履歴設定（~/.zsh ディレクトリは setup.sh で作成済みの前提）
 HISTFILE=~/.zsh/.zsh_history
 # フェールセーフ: ディレクトリが存在しなければ作成
-[[ -d "${HISTFILE:h}" ]] || mkdir -p "${HISTFILE:h}"
+[[ -d "${HISTFILE:h}" ]] || mkdir -p -m 700 "${HISTFILE:h}"
 export HISTSIZE=10000
 export SAVEHIST=50000
 # セッション間で履歴を即時共有

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env zsh
 
 # ---------------------------------------------
-# Zsh, Zinit, pipx, trash-cli セットアップスクリプト
+# Zsh 環境セットアップスクリプト
+# - 依存コマンドの確認 (git)
+# - Zinit (プラグインマネージャー) のインストール
+# - 設定ディレクトリの作成 (~/.zsh)
+# - 設定ファイルの配置 (.zshrc, .p10k.zsh)
 # ---------------------------------------------
 
 echo "Zsh環境のセットアップを開始します..."
@@ -14,6 +18,15 @@ if [ -z "$ZSH_VERSION" ]; then
     exit 1
 fi
 echo "情報: Zsh で実行されています (バージョン: $ZSH_VERSION)"
+echo "---------------------------------------------"
+
+
+# --- 依存コマンドの確認 ---
+if ! command -v git >/dev/null 2>&1; then
+    print -P "%F{160}エラー: git コマンドが見つかりません。インストールしてください。%f" >&2
+    exit 1
+fi
+echo "情報: git が利用可能です ($(git --version))"
 echo "---------------------------------------------"
 
 
@@ -37,6 +50,46 @@ if [[ ! -f "$ZINIT_DIR/zinit.zsh" ]]; then
     fi
 else
     echo "情報: Zinit は既にインストールされています。"
+fi
+echo "---------------------------------------------"
+
+
+# --- Zsh 設定ディレクトリの作成 ---
+ZSH_CONFIG_DIR="$HOME/.zsh"
+if [[ ! -d "$ZSH_CONFIG_DIR" ]]; then
+    mkdir -p "$ZSH_CONFIG_DIR"
+    chmod 700 "$ZSH_CONFIG_DIR"
+    echo "情報: $ZSH_CONFIG_DIR を作成しました。"
+else
+    echo "情報: $ZSH_CONFIG_DIR は既に存在します。"
+fi
+echo "---------------------------------------------"
+
+
+# --- 設定ファイルの配置 ---
+echo "設定ファイルを配置します..."
+# スクリプト自身のディレクトリを取得
+SCRIPT_DIR="${0:a:h}"
+
+# バックアップ用タイムスタンプ
+BACKUP_SUFFIX=".backup.$(date +%Y%m%d%H%M%S)"
+
+# .zshrc の配置
+if [[ -f "$HOME/.zshrc" ]]; then
+    cp -p "$HOME/.zshrc" "$HOME/.zshrc${BACKUP_SUFFIX}"
+    echo "情報: 既存の .zshrc を .zshrc${BACKUP_SUFFIX} にバックアップしました。"
+fi
+cp "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"
+echo "情報: .zshrc を配置しました。"
+
+# .p10k.zsh の配置
+if [[ -f "$SCRIPT_DIR/.zsh/.p10k.zsh" ]]; then
+    if [[ -f "$ZSH_CONFIG_DIR/.p10k.zsh" ]]; then
+        cp -p "$ZSH_CONFIG_DIR/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh${BACKUP_SUFFIX}"
+        echo "情報: 既存の .p10k.zsh を .p10k.zsh${BACKUP_SUFFIX} にバックアップしました。"
+    fi
+    cp "$SCRIPT_DIR/.zsh/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh"
+    echo "情報: .p10k.zsh を配置しました。"
 fi
 echo "---------------------------------------------"
 

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -57,8 +57,14 @@ echo "---------------------------------------------"
 # --- Zsh 設定ディレクトリの作成 ---
 ZSH_CONFIG_DIR="$HOME/.zsh"
 if [[ ! -d "$ZSH_CONFIG_DIR" ]]; then
-    mkdir -p "$ZSH_CONFIG_DIR"
-    chmod 700 "$ZSH_CONFIG_DIR"
+    if ! mkdir -p "$ZSH_CONFIG_DIR"; then
+        print -P "%F{160}エラー: $ZSH_CONFIG_DIR の作成に失敗しました。%f" >&2
+        exit 1
+    fi
+    if ! chmod 700 "$ZSH_CONFIG_DIR"; then
+        print -P "%F{160}エラー: $ZSH_CONFIG_DIR のパーミッション設定に失敗しました。%f" >&2
+        exit 1
+    fi
     echo "情報: $ZSH_CONFIG_DIR を作成しました。"
 else
     echo "情報: $ZSH_CONFIG_DIR は既に存在します。"
@@ -75,21 +81,39 @@ SCRIPT_DIR="${0:a:h}"
 BACKUP_SUFFIX=".backup.$(date +%Y%m%d%H%M%S)"
 
 # .zshrc の配置
+if [[ ! -f "$SCRIPT_DIR/.zshrc" ]]; then
+    print -P "%F{160}エラー: 配布元の .zshrc が見つかりません: $SCRIPT_DIR/.zshrc%f" >&2
+    exit 1
+fi
 if [[ -f "$HOME/.zshrc" ]]; then
-    cp -p "$HOME/.zshrc" "$HOME/.zshrc${BACKUP_SUFFIX}"
+    if ! cp -p "$HOME/.zshrc" "$HOME/.zshrc${BACKUP_SUFFIX}"; then
+        print -P "%F{160}エラー: .zshrc のバックアップに失敗しました。%f" >&2
+        exit 1
+    fi
     echo "情報: 既存の .zshrc を .zshrc${BACKUP_SUFFIX} にバックアップしました。"
 fi
-cp "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"
+if ! cp "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"; then
+    print -P "%F{160}エラー: .zshrc の配置に失敗しました。%f" >&2
+    exit 1
+fi
 echo "情報: .zshrc を配置しました。"
 
 # .p10k.zsh の配置
 if [[ -f "$SCRIPT_DIR/.zsh/.p10k.zsh" ]]; then
     if [[ -f "$ZSH_CONFIG_DIR/.p10k.zsh" ]]; then
-        cp -p "$ZSH_CONFIG_DIR/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh${BACKUP_SUFFIX}"
+        if ! cp -p "$ZSH_CONFIG_DIR/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh${BACKUP_SUFFIX}"; then
+            print -P "%F{160}エラー: .p10k.zsh のバックアップに失敗しました。%f" >&2
+            exit 1
+        fi
         echo "情報: 既存の .p10k.zsh を .p10k.zsh${BACKUP_SUFFIX} にバックアップしました。"
     fi
-    cp "$SCRIPT_DIR/.zsh/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh"
+    if ! cp "$SCRIPT_DIR/.zsh/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh"; then
+        print -P "%F{160}エラー: .p10k.zsh の配置に失敗しました。%f" >&2
+        exit 1
+    fi
     echo "情報: .p10k.zsh を配置しました。"
+else
+    print -P "%F{220}警告: .p10k.zsh が見つかりません。Powerlevel10k のデフォルト設定が使用されます。%f"
 fi
 echo "---------------------------------------------"
 


### PR DESCRIPTION
## 変更の概要

`dotfiles/setup.sh` にセットアップスクリプトとして不足していた機能を追加し、初回セットアップを一括で完了できるようにしました。

- `git` コマンドの事前チェックを追加（未インストール時にエラーメッセージ表示）
- `~/.zsh` 設定ディレクトリの作成処理を追加（`chmod 700`）
- `.zshrc` と `.p10k.zsh` の配置処理を追加（既存ファイルはタイムスタンプ付きバックアップ）
- `.zshrc` の `mkdir` 処理を `setup.sh` に移譲（フェールセーフは `.zshrc` に残留）
- ヘッダーコメントを最終的な実装内容に合わせて更新

## 変更の目的

- git 未インストール環境でのエラー原因を明確化
- 設定ファイルの手動配置を不要にし、セットアップの完全自動化を実現
- シェル起動時の不要なオーバーヘッド（毎回の mkdir チェック）を削減

## 関連Issue
- Close #3