### PR TITLE
fix: セキュリティ強化と XDG ディレクトリ仕様への準拠

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -27,7 +27,7 @@ setopt HIST_IGNORE_SPACE
 # ----------------------------
 # Zinit (プラグインマネージャー) の読み込みとプラグイン設定
 # ----------------------------
-ZINIT_HOME="$HOME/.local/share/zinit/zinit.git"
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
 if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
     source "$ZINIT_HOME/zinit.zsh"
 fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -32,17 +32,17 @@ echo "---------------------------------------------"
 
 # --- Zinit (プラグインマネージャー) のインストール ---
 echo "Zinit の状態を確認・インストールします..."
-ZINIT_DIR="$HOME/.local/share/zinit/zinit.git"
-if [[ ! -f "$ZINIT_DIR/zinit.zsh" ]]; then
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
+if [[ ! -f "$ZINIT_HOME/zinit.zsh" ]]; then
     print -P "%F{33} %F{220}Zinit (%F{33}zdharma-continuum/zinit%F{220}) をインストール中...%f"
-    # ディレクトリ作成と権限設定
-    if ! command mkdir -p "$(dirname "$ZINIT_DIR")"; then
+    # ディレクトリ作成
+    if ! command mkdir -p "$(dirname "$ZINIT_HOME")"; then
         print -P "%F{160}エラー: Zinit 用ディレクトリの作成に失敗しました。%f" >&2
         exit 1
     fi
     # git clone を実行（サプライチェーンリスク軽減のためタグをピン留め）
     ZINIT_VERSION="v3.14.0"
-    if command git clone --branch "$ZINIT_VERSION" --depth 1 https://github.com/zdharma-continuum/zinit "$ZINIT_DIR"; then
+    if command git clone --branch "$ZINIT_VERSION" --depth 1 https://github.com/zdharma-continuum/zinit "$ZINIT_HOME"; then
         print -P "%F{33} %F{34}Zinit ${ZINIT_VERSION} のインストールに成功しました。%f"
     else
         print -P "%F{160}エラー: Zinit の git clone に失敗しました。%f" >&2
@@ -57,12 +57,8 @@ echo "---------------------------------------------"
 # --- Zsh 設定ディレクトリの作成 ---
 ZSH_CONFIG_DIR="$HOME/.zsh"
 if [[ ! -d "$ZSH_CONFIG_DIR" ]]; then
-    if ! mkdir -p "$ZSH_CONFIG_DIR"; then
+    if ! mkdir -p -m 700 "$ZSH_CONFIG_DIR"; then
         print -P "%F{160}エラー: $ZSH_CONFIG_DIR の作成に失敗しました。%f" >&2
-        exit 1
-    fi
-    if ! chmod 700 "$ZSH_CONFIG_DIR"; then
-        print -P "%F{160}エラー: $ZSH_CONFIG_DIR のパーミッション設定に失敗しました。%f" >&2
         exit 1
     fi
     echo "情報: $ZSH_CONFIG_DIR を作成しました。"

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -57,7 +57,7 @@ echo "---------------------------------------------"
 # --- Zsh 設定ディレクトリの作成 ---
 ZSH_CONFIG_DIR="$HOME/.zsh"
 if [[ ! -d "$ZSH_CONFIG_DIR" ]]; then
-    if ! mkdir -p -m 700 "$ZSH_CONFIG_DIR"; then
+    if ! command mkdir -p -m 700 "$ZSH_CONFIG_DIR"; then
         print -P "%F{160}エラー: $ZSH_CONFIG_DIR の作成に失敗しました。%f" >&2
         exit 1
     fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -35,8 +35,8 @@ echo "Zinit の状態を確認・インストールします..."
 ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
 if [[ ! -f "$ZINIT_HOME/zinit.zsh" ]]; then
     print -P "%F{33} %F{220}Zinit (%F{33}zdharma-continuum/zinit%F{220}) をインストール中...%f"
-    # ディレクトリ作成
-    if ! command mkdir -p "$(dirname "$ZINIT_HOME")"; then
+    # ディレクトリ作成（パーミッションは 700 に固定）
+    if ! command mkdir -p -m 700 "$(dirname "$ZINIT_HOME")"; then
         print -P "%F{160}エラー: Zinit 用ディレクトリの作成に失敗しました。%f" >&2
         exit 1
     fi


### PR DESCRIPTION
## 変更の概要

- `setup.sh`: `mkdir -p` + `chmod 700` を `mkdir -p -m 700` に単一化（TOCTOU 競合状態の排除）
- `setup.sh` & `.zshrc`: Zinit パスを `${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git` に変更（XDG Base Directory Specification 準拠）
- `setup.sh`: 変数名 `ZINIT_DIR` → `ZINIT_HOME` に統一（`.zshrc` との一貫性確保）
- `setup.sh`: コメントの不整合を修正（Gemini レビュー指摘）

## 変更の目的

1. ディレクトリ作成時のパーミッション露出リスク排除（セキュリティ強化）
2. `XDG_DATA_HOME` 環境変数を設定しているユーザーへの正しい対応（仕様準拠）
3. 両ファイル間の変数名統一によるメンテナンス性向上

## 関連 Issue

- Close #9
- #10 の変数名統一タスクも本 PR で前倒し対応済み

## レビュー情報

- 構文チェック (`zsh -n`) パス済み
- Gemini MCP クロスレビュー済み（コメント不整合の指摘を反映）