### PR TITLE
fix: シンボリックリンク対応とプラグインクローン安全性の改善

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -60,8 +60,8 @@ if (( $+functions[zinit] )); then
     zinit ice wait lucid ver"v0.7.1"
     zinit light zsh-users/zsh-autosuggestions
     # 複数単語での履歴検索 (c4dcddc)
-    # コミットハッシュ指定のためフルクローンが必要（depth=0）
-    zinit ice wait lucid depth=0 ver"c4dcddc"
+    # コミットハッシュ指定のためフルクローンが必要（depth 省略 = フルクローン）
+    zinit ice wait lucid ver"c4dcddc"
     zinit light zdharma-continuum/history-search-multi-word
     # シンタックスハイライト (プラグイン群の中で最後に読み込む) (0.8.0)
     zinit ice wait lucid ver"0.8.0"

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -60,7 +60,8 @@ if (( $+functions[zinit] )); then
     zinit ice wait lucid ver"v0.7.1"
     zinit light zsh-users/zsh-autosuggestions
     # 複数単語での履歴検索 (c4dcddc)
-    zinit ice wait lucid ver"c4dcddc"
+    # コミットハッシュ指定のためフルクローンが必要（depth=0）
+    zinit ice wait lucid depth=0 ver"c4dcddc"
     zinit light zdharma-continuum/history-search-multi-word
     # シンタックスハイライト (プラグイン群の中で最後に読み込む) (0.8.0)
     zinit ice wait lucid ver"0.8.0"

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -83,8 +83,9 @@ if [[ ! -f "$SCRIPT_DIR/.zshrc" ]]; then
     print -P "%F{160}エラー: 配布元の .zshrc が見つかりません: $SCRIPT_DIR/.zshrc%f" >&2
     exit 1
 fi
-if [[ -f "$ZSHRC_DEST" ]]; then
-    if ! command cp -p "$ZSHRC_DEST" "${ZSHRC_DEST}${BACKUP_SUFFIX}"; then
+# シンボリックリンクの場合もバックアップ対象（-h でリンク自体を検出）
+if [[ -f "$ZSHRC_DEST" || -h "$ZSHRC_DEST" ]]; then
+    if ! command mv "$ZSHRC_DEST" "${ZSHRC_DEST}${BACKUP_SUFFIX}"; then
         print -P "%F{160}エラー: .zshrc のバックアップに失敗しました。%f" >&2
         exit 1
     fi
@@ -98,12 +99,13 @@ print -P "情報: .zshrc を $ZSHRC_DEST に配置しました。"
 
 # .p10k.zsh の配置
 if [[ -f "$SCRIPT_DIR/.zsh/.p10k.zsh" ]]; then
-    if [[ -f "$ZSH_CONFIG_DIR/.p10k.zsh" ]]; then
-        if ! command cp -p "$ZSH_CONFIG_DIR/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh${BACKUP_SUFFIX}"; then
+    # シンボリックリンクの場合もバックアップ対象
+    if [[ -f "$ZSH_CONFIG_DIR/.p10k.zsh" || -h "$ZSH_CONFIG_DIR/.p10k.zsh" ]]; then
+        if ! command mv "$ZSH_CONFIG_DIR/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh${BACKUP_SUFFIX}"; then
             print -P "%F{160}エラー: .p10k.zsh のバックアップに失敗しました。%f" >&2
             exit 1
         fi
-        print -P "情報: 既存の .p10k.zsh を .p10k.zsh${BACKUP_SUFFIX} にバックアップしました。"
+        print -P "情報: 既存の .p10k.zsh を ${ZSH_CONFIG_DIR}/.p10k.zsh${BACKUP_SUFFIX} にバックアップしました。"
     fi
     if ! command cp -p "$SCRIPT_DIR/.zsh/.p10k.zsh" "$ZSH_CONFIG_DIR/.p10k.zsh"; then
         print -P "%F{160}エラー: .p10k.zsh の配置に失敗しました。%f" >&2


### PR DESCRIPTION
## 変更の概要

- `setup.sh`: バックアップ処理を `cp -p` → `mv` に変更し、`-h`（シンボリックリンク）チェックを追加
- `.zshrc`: `history-search-multi-word` に `depth=0` を明示追加

## 変更の目的

1. **シンボリックリンク安全性**: Stow 等で dotfiles を管理しているユーザーの場合、既存ファイルがシンボリックリンクであると `cp -p` がリンク先の実体ファイルを上書きしてしまう。`mv` でリンクごとバックアップすることでデータ破壊を防止。
2. **プラグインクローン安全性**: `ver"c4dcddc"` でコミットハッシュを指定しているが、`depth=1`（Shallow Clone）では当該コミットが取得されない。`depth=0` を明示することでフルクローンを保証し、将来の変更で checkout が失敗するリスクを排除。

## 関連 Issue

- Close #15

## レビュー情報

- 構文チェック (`zsh -n`) パス済み
- Gemini MCP 最終レビューでの指摘を反映