### PR TITLE
feat: fzf + fzf-tab プラグインの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ zsh dotfiles/setup.sh
 |-----------|------|
 | [Powerlevel10k](https://github.com/romkatv/powerlevel10k) | 高速・高機能なプロンプトテーマ |
 | [zsh-completions](https://github.com/zsh-users/zsh-completions) | 追加の補完定義 |
+| [fzf](https://github.com/junegunn/fzf) | ファジーファインダー（Ctrl-R: 履歴検索, Ctrl-T: ファイル検索, Alt-C: ディレクトリ移動） |
+| [fzf-tab](https://github.com/Aloxaf/fzf-tab) | Tab 補完を fzf に置き換え（プレビュー付き補完メニュー） |
 | [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) | 履歴ベースのコマンド候補表示 |
-| [history-search-multi-word](https://github.com/zdharma-continuum/history-search-multi-word) | 複数単語での履歴検索 |
 | [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) | コマンドラインのシンタックスハイライト |
 
 ## ディレクトリ構成

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -54,8 +54,11 @@ if (( $+functions[zinit] )); then
     compdef _zinit zinit
 
     # --- fzf (ファジーファインダー) ---
-    # GitHub Releases からプラットフォーム固有のバイナリを自動インストール (v0.70.0)
-    zinit ice from"gh-r" as"program" ver"v0.70.0"
+    # バージョンを変数で一元管理（バイナリと shell スクリプトの不整合を防止）
+    FZF_VERSION="v0.70.0"
+    FZF_RAW_URL="https://raw.githubusercontent.com/junegunn/fzf/${FZF_VERSION}/shell"
+    # GitHub Releases からプラットフォーム固有のバイナリを自動インストール
+    zinit ice from"gh-r" as"program" ver"${FZF_VERSION}"
     zinit light junegunn/fzf
     # fzf-tab: Tab 補完を fzf に置き換え (v1.2.0)
     # NOTE: compinit の後、かつ autosuggestions/syntax-highlighting より前に読み込む
@@ -67,10 +70,10 @@ if (( $+functions[zinit] )); then
 
     # fzf キーバインディング (Ctrl-R: 履歴検索, Ctrl-T: ファイル検索, Alt-C: ディレクトリ移動)
     zinit ice wait lucid
-    zinit snippet https://raw.githubusercontent.com/junegunn/fzf/v0.70.0/shell/key-bindings.zsh
+    zinit snippet "${FZF_RAW_URL}/key-bindings.zsh"
     # fzf 補完 (** トリガー)
     zinit ice wait lucid
-    zinit snippet https://raw.githubusercontent.com/junegunn/fzf/v0.70.0/shell/completion.zsh
+    zinit snippet "${FZF_RAW_URL}/completion.zsh"
 
     # オートサジェスチョン (v0.7.1)
     zinit ice wait lucid ver"v0.7.1"

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -53,16 +53,28 @@ if (( $+functions[zinit] )); then
     autoload -Uz _zinit
     compdef _zinit zinit
 
+    # --- fzf (ファジーファインダー) ---
+    # GitHub Releases からプラットフォーム固有のバイナリを自動インストール (v0.70.0)
+    zinit ice from"gh-r" as"program" ver"v0.70.0"
+    zinit light junegunn/fzf
+    # fzf-tab: Tab 補完を fzf に置き換え (v1.2.0)
+    # NOTE: compinit の後、かつ autosuggestions/syntax-highlighting より前に読み込む
+    zinit ice ver"v1.2.0"
+    zinit light Aloxaf/fzf-tab
+
     # --- Turbo mode（遅延読み込み）---
     # プロンプト表示後にバックグラウンドで読み込み、シェル起動を高速化
+
+    # fzf キーバインディング (Ctrl-R: 履歴検索, Ctrl-T: ファイル検索, Alt-C: ディレクトリ移動)
+    zinit ice wait lucid
+    zinit snippet https://raw.githubusercontent.com/junegunn/fzf/v0.70.0/shell/key-bindings.zsh
+    # fzf 補完 (** トリガー)
+    zinit ice wait lucid
+    zinit snippet https://raw.githubusercontent.com/junegunn/fzf/v0.70.0/shell/completion.zsh
 
     # オートサジェスチョン (v0.7.1)
     zinit ice wait lucid ver"v0.7.1"
     zinit light zsh-users/zsh-autosuggestions
-    # 複数単語での履歴検索 (c4dcddc)
-    # コミットハッシュ指定のためフルクローンが必要（depth 省略 = フルクローン）
-    zinit ice wait lucid ver"c4dcddc"
-    zinit light zdharma-continuum/history-search-multi-word
     # シンタックスハイライト (プラグイン群の中で最後に読み込む) (0.8.0)
     zinit ice wait lucid ver"0.8.0"
     zinit light zsh-users/zsh-syntax-highlighting


### PR DESCRIPTION
## 変更の概要

- fzf バイナリを Zinit の `from"gh-r"` で GitHub Releases から自動インストール (`v0.70.0`)
- fzf-tab で Tab 補完を fzf に置き換え (`v1.2.0`)
- fzf キーバインディング（Ctrl-R / Ctrl-T / Alt-C）と補完（`**` トリガー）を Turbo mode で遅延読み込み
- `history-search-multi-word` を削除し、Ctrl-R を fzf に統一
- README.md のプラグイン一覧を更新

## 変更の目的

ターミナル操作の生産性向上。fzf によるファジー検索で履歴検索・ファイル検索・Tab 補完が大幅に強化される。

## 関連 Issue

- Close #17

## レビュー情報

- 構文チェック (`zsh -n`) パス済み
- Gemini MCP クロスレビュー済み（技術的欠陥なし）
- 読み込み順序: fzf バイナリ → fzf-tab（同期、compinit 直後）→ fzf キーバインディング/補完（Turbo）→ autosuggestions → syntax-highlighting