### PR TITLE
feat: GitHub Actions CI ワークフロー追加（zsh -n 構文チェック）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Zsh
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
       - name: Verify Zsh is available
         run: zsh --version
       - name: Run zsh -n

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'dotfiles/**'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zsh-syntax:
+    name: Zsh Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify Zsh is available
+        run: zsh --version
+      - name: Run zsh -n
+        run: |
+          status=0
+          while IFS= read -r -d '' f; do
+            echo "::group::$f"
+            if zsh -n "$f"; then
+              echo "OK: $f"
+            else
+              echo "::error file=$f::Syntax error in $f"
+              status=1
+            fi
+            echo "::endgroup::"
+          done < <(find dotfiles -type f \( -name '*.zsh' -o -name '*.sh' -o -name '.zshrc' \) ! -name '.p10k.zsh' -print0 | sort -z)
+          exit $status


### PR DESCRIPTION
## 変更の概要\n\nPR 作成・更新時に `zsh -n` による構文チェックを自動実行する GitHub Actions ワークフロー（`.github/workflows/ci.yml`）を追加しました。\n\n## 変更の目的\n\n構文チェックを手動実行に頼っており、見落としリスクがあったため、CI で自動化することでコード品質を担保します。\n\n## 変更内容\n\n- `.github/workflows/ci.yml` を新規作成\n  - **トリガー**: `pull_request`（main ブランチ向け）かつ `dotfiles/**` または `.github/workflows/**` の変更時\n  - **ジョブ**: `zsh -n` で全シェルスクリプトの構文チェック\n  - **除外**: `.p10k.zsh`（Powerlevel10k 自動生成ファイル）\n  - **権限**: `contents: read` に最小化\n  - **エラー表示**: GitHub Actions の `::error` アノテーションで PR 上にインライン表示\n\n## 関連Issue\n\n- Close #22