### PR TITLE
feat: プロジェクト基盤整備 (.gitignore 補完 + .editorconfig 追加)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,28 @@
+# 環境変数
 *.env
+.env.local
 
 # ログファイル
 *.log
 
 # キャッシュ
 .cache/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# エディタ
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# Node.js
+node_modules/
+
+# Python
+.venv/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ dev-templates/
 │   │   └── .p10k.zsh      # Powerlevel10k 設定
 │   ├── .zshrc              # エントリーポイント（履歴設定 + モジュール読み込み）
 │   └── setup.sh            # セットアップスクリプト（インタラクティブ選択対応）
+├── .editorconfig              # エディタ設定（インデント・改行コード統一）
 ├── .gitignore
 └── README.md
 ```


### PR DESCRIPTION
## 概要

プロジェクトの基盤設定ファイルを整備し、不要ファイルの誤コミット防止とエディタ間の設定統一を図る。

## 変更内容

### .gitignore 補完
- OS メタデータ (.DS_Store, Thumbs.db)
- エディタ一時ファイル (*.swp, *.swo, *~, .vscode/, .idea/)
- Node.js (node_modules/)
- Python (.venv/, __pycache__/, *.pyc)
- 環境変数 (.env.local)

### .editorconfig 新規追加
- UTF-8, LF, 末尾空白削除, 最終行改行
- デフォルト: スペース4インデント
- YAML: スペース2インデント
- Makefile: タブインデント

### README.md
- ディレクトリ構成に .editorconfig を追記

Close #30