### PR TITLE
feat: CI 強化 - dry-run テスト・macOS マトリクス・shfmt チェック

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,15 @@ permissions:
 
 jobs:
   zsh-syntax:
-    name: Zsh Syntax Check
-    runs-on: ubuntu-latest
+    name: Zsh Syntax Check (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Zsh
+        if: runner.os == 'Linux'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
       - name: Verify Zsh is available
         run: zsh --version
@@ -34,3 +38,19 @@ jobs:
             echo "::endgroup::"
           done < <(find dotfiles -type f \( -name '*.zsh' -o -name '*.sh' -o -name '.zshrc' \) ! -name '.p10k.zsh' -print0 | sort -z)
           exit $status
+
+  dry-run:
+    name: Setup Dry Run (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Zsh
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
+      - name: Verify Zsh is available
+        run: zsh --version
+      - name: Run setup.sh --all --dry-run
+        run: zsh dotfiles/setup.sh --all --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               status=1
             fi
             echo "::endgroup::"
-          done < <(find dotfiles -type f \( -name '*.zsh' -o -name '*.sh' -o -name '.zshrc' \) ! -name '.p10k.zsh' -print0 | sort -z)
+          done < <(find dotfiles -type f \( -name '*.zsh' -o -name '*.sh' -o -name '.zshrc' \) ! -name '.p10k.zsh' -print0)
           exit $status
 
   dry-run:
@@ -64,9 +64,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install shfmt
         run: |
-          curl -fL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o shfmt
-          chmod +x shfmt
-          sudo mv shfmt /usr/local/bin/
+          go install mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
       - name: Check shell format
         run: |
           status=0
@@ -80,5 +79,5 @@ jobs:
               status=1
             fi
             echo "::endgroup::"
-          done < <(find dotfiles/.zsh -type f -name '*.zsh' ! -name '.p10k.zsh' -print0 | sort -z)
+          done < <(find dotfiles/.zsh -type f -name '*.zsh' ! -name '.p10k.zsh' -print0)
           exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   zsh-syntax:
     name: Zsh Syntax Check (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -42,6 +43,7 @@ jobs:
   dry-run:
     name: Setup Dry Run (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -54,3 +56,29 @@ jobs:
         run: zsh --version
       - name: Run setup.sh --all --dry-run
         run: zsh dotfiles/setup.sh --all --dry-run
+
+  shell-format:
+    name: Shell Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shfmt
+        run: |
+          curl -fL https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64 -o shfmt
+          chmod +x shfmt
+          sudo mv shfmt /usr/local/bin/
+      - name: Check shell format
+        run: |
+          status=0
+          # .zsh/*.zsh ファイルのみチェック（Zsh特有構文を含む .zshrc と setup.sh は除外）
+          while IFS= read -r -d '' f; do
+            echo "::group::$f"
+            if shfmt -d "$f"; then
+              echo "OK: $f"
+            else
+              echo "::error file=$f::Format check failed for $f"
+              status=1
+            fi
+            echo "::endgroup::"
+          done < <(find dotfiles/.zsh -type f -name '*.zsh' ! -name '.p10k.zsh' -print0 | sort -z)
+          exit $status

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ zsh dotfiles/setup.sh --uninstall
 
 - **Zsh 構文チェック** (`zsh -n`): `dotfiles/` 配下の `.zsh`, `.sh`, `.zshrc` ファイル（`.p10k.zsh` を除く）の構文エラーを検出
 - **Setup Dry Run**: `setup.sh --all --dry-run` を実行し、セットアップスクリプトの動作を検証
+- **Shell Format Check**: `shfmt` による `.zsh/*.zsh` ファイルのフォーマットチェック
 
-各チェックは **Ubuntu** と **macOS** の両環境で実行されます。
+構文チェックと dry-run は **Ubuntu** と **macOS** の両環境で実行されます。
 
 ## ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -112,13 +112,16 @@ zsh dotfiles/setup.sh --uninstall
 `dotfiles/**` または `.github/workflows/**` に変更を含む Pull Request で、GitHub Actions によるチェックが自動実行されます:
 
 - **Zsh 構文チェック** (`zsh -n`): `dotfiles/` 配下の `.zsh`, `.sh`, `.zshrc` ファイル（`.p10k.zsh` を除く）の構文エラーを検出
+- **Setup Dry Run**: `setup.sh --all --dry-run` を実行し、セットアップスクリプトの動作を検証
+
+各チェックは **Ubuntu** と **macOS** の両環境で実行されます。
 
 ## ディレクトリ構成
 
 ```
 dev-templates/
 ├── .github/workflows/
-│   └── ci.yml              # CI: zsh -n 構文チェック
+│   └── ci.yml              # CI: 構文チェック + dry-run テスト（Ubuntu/macOS）
 ├── dotfiles/
 │   ├── .zsh/
 │   │   ├── plugins.zsh    # Zinit プラグイン設定

--- a/dotfiles/.zsh/plugins.zsh
+++ b/dotfiles/.zsh/plugins.zsh
@@ -8,7 +8,7 @@ fi
 
 # zinit 関数が正常に定義されている場合のみプラグインを読み込む
 # NOTE: shfmt 互換のため $+functions[] ではなく ${functions[]} で存在チェック
-if [[ -n ${functions[zinit]} ]]; then
+if [[ -n "${functions[zinit]}" ]]; then
 
     # Powerlevel10k テーマ (v1.9.1)
     zinit ice depth=1 ver"v1.9.1"

--- a/dotfiles/.zsh/plugins.zsh
+++ b/dotfiles/.zsh/plugins.zsh
@@ -7,15 +7,18 @@ if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
 fi
 
 # zinit 関数が正常に定義されている場合のみプラグインを読み込む
-if (( $+functions[zinit] )); then
+# NOTE: shfmt 互換のため $+functions[] ではなく ${functions[]} で存在チェック
+if [[ -n ${functions[zinit]} ]]; then
 
     # Powerlevel10k テーマ (v1.9.1)
-    zinit ice depth=1 ver"v1.9.1"; zinit light romkatv/powerlevel10k
+    zinit ice depth=1 ver"v1.9.1"
+    zinit light romkatv/powerlevel10k
     # Powerlevel10k ユーザー設定ファイルが存在すれば source
     [[ ! -f "${ZDOTDIR:-$HOME}/.zsh/.p10k.zsh" ]] || source "${ZDOTDIR:-$HOME}/.zsh/.p10k.zsh"
 
     # コンプリーション (fpathに追加するため compinit より前に読み込む) (0.9.0)
-    zinit ice ver"0.9.0"; zinit light zsh-users/zsh-completions
+    zinit ice ver"0.9.0"
+    zinit light zsh-users/zsh-completions
 
     # 補完システムの初期化（Zinit のキャッシュ最適化版を使用）
     autoload -Uz compinit


### PR DESCRIPTION
## 概要

CI パイプラインを強化し、setup.sh の動作検証とコードフォーマットの一貫性を自動チェックする。

## 変更内容

### dry-run テストの追加
- `zsh dotfiles/setup.sh --all --dry-run` を CI ジョブとして追加
- dry-run が正常終了することを検証

### マルチ OS マトリクス
- 構文チェック・dry-run を Ubuntu + macOS の両環境で実行
- `fail-fast: false` で一方の失敗が他方をキャンセルしないよう設定

### shfmt フォーマットチェック
- `dotfiles/.zsh/*.zsh` ファイルを対象にフォーマットチェック
- Zsh 特有構文を含む `.zshrc` / `setup.sh` は対象外（shfmt 非対応のため）
- `plugins.zsh` を shfmt 準拠にフォーマット修正

## テスト計画

- [ ] CI の全ジョブ（zsh-syntax, dry-run, shell-format）が Ubuntu/macOS で通ること
- [ ] shfmt フォーマットチェックが対象ファイルで正常に動作すること

Close #31