### PR TITLE
feat: aliases.zsh に git/docker エイリアスと fzf 連携関数を追加

### DIFF
--- a/dotfiles/.zsh/aliases.zsh
+++ b/dotfiles/.zsh/aliases.zsh
@@ -29,11 +29,12 @@ alias dps='docker ps'
 # ----------------------------
 
 # git ブランチを fzf で検索してチェックアウト
-gco-fzf() {
+gco_fzf() {
     command -v fzf >/dev/null 2>&1 || { echo "fzf が必要です" >&2; return 1; }
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Git リポジトリ内で実行してください" >&2; return 1; }
     local branch
     branch=$(git branch --all --format='%(refname:short)' |
-        grep -v 'HEAD' |
+        grep -v '^origin/HEAD$' |
         fzf --height 40% --reverse --prompt="checkout> ") || return
     # リモートブランチの場合は origin/ プレフィックスを除去
     branch=${branch#origin/}
@@ -42,7 +43,7 @@ gco-fzf() {
 
 # ghq リポジトリを fzf で検索して移動
 if command -v ghq >/dev/null 2>&1 && command -v fzf >/dev/null 2>&1; then
-    ghq-fzf() {
+    ghq_fzf() {
         local dir
         dir=$(ghq list --full-path |
             fzf --height 40% --reverse --prompt="repo> ") || return

--- a/dotfiles/.zsh/aliases.zsh
+++ b/dotfiles/.zsh/aliases.zsh
@@ -30,8 +30,14 @@ alias dps='docker ps'
 
 # git ブランチを fzf で検索してチェックアウト
 gco_fzf() {
-    command -v fzf >/dev/null 2>&1 || { echo "fzf が必要です" >&2; return 1; }
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Git リポジトリ内で実行してください" >&2; return 1; }
+    command -v fzf >/dev/null 2>&1 || {
+        echo "fzf が必要です" >&2
+        return 1
+    }
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+        echo "Git リポジトリ内で実行してください" >&2
+        return 1
+    }
     local branch
     branch=$(git branch --all --format='%(refname:short)' |
         grep -v '^origin/HEAD$' |

--- a/dotfiles/.zsh/aliases.zsh
+++ b/dotfiles/.zsh/aliases.zsh
@@ -3,3 +3,49 @@
 # ----------------------------
 alias ls='ls --color=auto'
 alias la='ls -a'
+
+# ----------------------------
+# git エイリアス
+# ----------------------------
+alias gs='git status'
+alias ga='git add'
+alias gc='git commit'
+alias gp='git push'
+alias gl='git log --oneline --graph'
+alias gd='git diff'
+alias gco='git checkout'
+alias gb='git branch'
+
+# ----------------------------
+# docker エイリアス
+# ----------------------------
+alias dc='docker compose'
+alias dcu='docker compose up -d'
+alias dcd='docker compose down'
+alias dps='docker ps'
+
+# ----------------------------
+# fzf 連携関数
+# ----------------------------
+
+# git ブランチを fzf で検索してチェックアウト
+gco-fzf() {
+    command -v fzf >/dev/null 2>&1 || { echo "fzf が必要です" >&2; return 1; }
+    local branch
+    branch=$(git branch --all --format='%(refname:short)' |
+        grep -v 'HEAD' |
+        fzf --height 40% --reverse --prompt="checkout> ") || return
+    # リモートブランチの場合は origin/ プレフィックスを除去
+    branch=${branch#origin/}
+    git checkout "$branch"
+}
+
+# ghq リポジトリを fzf で検索して移動
+if command -v ghq >/dev/null 2>&1 && command -v fzf >/dev/null 2>&1; then
+    ghq-fzf() {
+        local dir
+        dir=$(ghq list --full-path |
+            fzf --height 40% --reverse --prompt="repo> ") || return
+        cd "$dir" || return
+    }
+fi


### PR DESCRIPTION
## 概要

日常的な開発操作を効率化するため、aliases.zsh にエイリアスと fzf 連携関数を追加する。

## 変更内容

### git エイリアス
`gs`, `ga`, `gc`, `gp`, `gl`, `gd`, `gco`, `gb`

### docker エイリアス
`dc`, `dcu`, `dcd`, `dps`

### fzf 連携関数
- **gco-fzf**: git ブランチを fzf で検索してチェックアウト（`origin/HEAD` 除外済み）
- **ghq-fzf**: ghq リポジトリを fzf で検索して移動（ghq + fzf が存在する場合のみ定義）

## テスト計画

- [ ] CI の全ジョブ（zsh-syntax, dry-run, shell-format）が通ること
- [ ] fzf 連携関数にコマンド存在チェックが入っていること

Close #32