### PR TITLE
refactor: .zshrc のモジュール設定読み込みを glob ループに変更

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -42,11 +42,12 @@ else
     autoload -Uz compinit && compinit
 fi
 
-# エイリアス定義
-[[ -f "$ZSH_CONFIG_DIR/aliases.zsh" ]] && source "$ZSH_CONFIG_DIR/aliases.zsh"
-
-# Node.js 環境（fnm）
-[[ -f "$ZSH_CONFIG_DIR/node.zsh" ]] && source "$ZSH_CONFIG_DIR/node.zsh"
-
-# Python 環境（pyenv）
-[[ -f "$ZSH_CONFIG_DIR/python.zsh" ]] && source "$ZSH_CONFIG_DIR/python.zsh"
+# モジュール設定の自動読み込み
+# plugins.zsh は上で読み込み済み、.p10k.zsh は Zinit 経由で読み込み
+for _zsh_config_file in "$ZSH_CONFIG_DIR"/*.zsh(N); do
+    case "${_zsh_config_file:t}" in
+        plugins.zsh|.p10k.zsh) continue ;;
+        *) source "$_zsh_config_file" ;;
+    esac
+done
+unset _zsh_config_file


### PR DESCRIPTION
## 概要

`.zshrc` のモジュール設定ファイル読み込みを、個別 `source` 行から glob ループ方式にリファクタリング。

## 変更内容

- `aliases.zsh`, `node.zsh`, `python.zsh` の個別 source 行を `$ZSH_CONFIG_DIR/*.zsh(N)` glob ループに統合
- `plugins.zsh`（既に読み込み済み）と `.p10k.zsh`（Zinit 経由）は `case` 文で除外
- ループ変数 `_zsh_config_file` は使用後に `unset`

## メリット

- 新モジュール追加時に `.zshrc` の変更が不要になる
- `modules/*.sh` → `install_config` で `.zsh/*.zsh` を配置するだけで完結
- モジュールシステムの「ファイルを置くだけ」という設計思想と一致

## 注意点

- 読み込み順序が glob のアルファベット順になる（現在の aliases→node→python と一致）
- `(N)` glob qualifier によりマッチなしでもエラーにならない

Close #44