### PR TITLE
feat: Docker Compose + Dev Containers で開発環境を構築

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "dev-templates",
+    "dockerComposeFile": "../docker-compose.yml",
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/dev-templates",
+    "remoteUser": "dev",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "timonwong.shellcheck",
+                "foxundermoon.shell-format",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.devcontainer
+.env
+.env.*
+!.env.example
+node_modules
+*.log
+.DS_Store
+.vscode
+.idea

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Claude Code
+ANTHROPIC_API_KEY=
+
+# Gemini CLI
+GEMINI_API_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,16 @@ RUN userdel -r ubuntu 2>/dev/null || true \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # fnm + Node.js LTS を事前インストール
-# NOTE: Docker ビルド内では GitHub リダイレクトが不安定なため、
-#       setup.sh の node モジュールに頼らず直接インストールする
+# NOTE: ピン留めされたバージョンの公式バイナリを GitHub Releases から直接取得する
+ARG FNM_VERSION=v1.38.1
 USER $USERNAME
 ENV FNM_DIR="/home/${USERNAME}/.local/share/fnm"
 RUN mkdir -p /home/${USERNAME}/.local/bin \
-    && curl -fsSL https://fnm.vercel.app/install \
-       | bash -s -- --install-dir /home/${USERNAME}/.local/bin --skip-shell \
+    && curl -fsSL "https://github.com/Schniz/fnm/releases/download/${FNM_VERSION}/fnm-linux.zip" \
+       -o /tmp/fnm.zip \
+    && unzip -o /tmp/fnm.zip -d /home/${USERNAME}/.local/bin \
+    && chmod +x /home/${USERNAME}/.local/bin/fnm \
+    && rm /tmp/fnm.zip \
     && export PATH="/home/${USERNAME}/.local/bin:$PATH" \
     && eval "$(fnm env)" \
     && fnm install --lts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:24.04
 
 # 対話的プロンプトを抑制
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Tokyo
 
 # 全モジュールの前提パッケージを一括インストール

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# ==============================================
+# 開発環境コンテナ
+# setup.sh --all で全モジュールをプリインストールした Zsh 環境
+# ==============================================
+
+FROM ubuntu:24.04
+
+# 対話的プロンプトを抑制
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+# 全モジュールの前提パッケージを一括インストール
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # 基本ツール
+    zsh \
+    git \
+    curl \
+    wget \
+    unzip \
+    sudo \
+    ca-certificates \
+    locales \
+    # modern-cli (eza) 用
+    gpg \
+    # Python ビルド依存パッケージ
+    build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libncursesw5-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libffi-dev \
+    liblzma-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ロケール設定
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# 非 root ユーザーの作成（パスワードなし sudo）
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m -s /usr/bin/zsh $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# fnm + Node.js LTS を事前インストール
+# NOTE: Docker ビルド内では GitHub リダイレクトが不安定なため、
+#       setup.sh の node モジュールに頼らず直接インストールする
+USER $USERNAME
+ENV FNM_DIR="/home/${USERNAME}/.local/share/fnm"
+RUN mkdir -p /home/${USERNAME}/.local/bin \
+    && curl -fsSL https://fnm.vercel.app/install \
+       | bash -s -- --install-dir /home/${USERNAME}/.local/bin --skip-shell \
+    && export PATH="/home/${USERNAME}/.local/bin:$PATH" \
+    && eval "$(fnm env)" \
+    && fnm install --lts \
+    && fnm default lts-latest
+ENV PATH="/home/${USERNAME}/.local/bin:$PATH"
+
+# dotfiles をコピーして setup.sh を実行
+WORKDIR /home/$USERNAME
+COPY --chown=$USERNAME:$USERNAME dotfiles/ /tmp/dotfiles/
+RUN cd /tmp/dotfiles && zsh setup.sh --all \
+    && rm -rf /tmp/dotfiles
+
+WORKDIR /workspaces
+CMD ["zsh"]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,48 @@ zsh dotfiles/setup.sh --uninstall
 | [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) | 履歴ベースのコマンド候補表示 |
 | [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) | コマンドラインのシンタックスハイライト |
 
+## Docker (Dev Containers)
+
+Docker Compose + VS Code Dev Containers でコンテナ内に開発環境を構築できます。
+
+### セットアップ
+
+```bash
+# .env ファイルを作成して API キーを設定
+cp .env.example .env
+# .env を編集して ANTHROPIC_API_KEY 等を設定
+
+# コンテナをビルド
+docker compose build
+
+# コンテナを起動
+docker compose up -d
+docker compose exec devcontainer zsh
+```
+
+VS Code / Cursor から Dev Containers として接続する場合は、コマンドパレットから「Dev Containers: Reopen in Container」を実行してください。
+
+### 含まれるツール
+
+コンテナイメージには `setup.sh --all` で全モジュールがプリインストールされています:
+
+- Zsh + Zinit + Powerlevel10k
+- Git グローバル設定
+- モダン CLI ツール (eza, bat, fd, ripgrep)
+- Node.js (fnm + LTS)
+- Claude Code
+- Python (pyenv)
+- Gemini CLI
+
+### API キーの設定
+
+`.env` ファイルに API キーを記述すると、コンテナ内の環境変数として利用できます:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+GEMINI_API_KEY=...
+```
+
 ## CI
 
 `dotfiles/**` または `.github/workflows/**` に変更を含む Pull Request で、GitHub Actions によるチェックが自動実行されます:
@@ -156,8 +198,13 @@ zsh dotfiles/setup.sh --uninstall
 
 ```
 dev-templates/
+├── .devcontainer/
+│   └── devcontainer.json     # VS Code Dev Containers 設定
 ├── .github/workflows/
 │   └── ci.yml                # CI: 構文チェック + dry-run テスト（Ubuntu/macOS）
+├── Dockerfile                 # 開発環境コンテナ定義
+├── docker-compose.yml         # Docker Compose 設定
+├── .env.example               # 環境変数テンプレート（API キー等）
 ├── dotfiles/
 │   ├── .zsh/
 │   │   ├── plugins.zsh      # Zinit プラグイン設定

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ zsh dotfiles/setup.sh --uninstall
 
 Docker Compose + VS Code Dev Containers でコンテナ内に開発環境を構築できます。
 
+- **Docker Compose v2.24+** が必要です（`env_file` の `required` オプションを使用）
+
 ### セットアップ
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/workspaces/dev-templates
+    env_file:
+      - path: .env
+        required: false
+    tty: true
+    stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/workspaces/dev-templates
+    working_dir: /workspaces/dev-templates
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## 概要

Docker Compose + VS Code Dev Containers でコンテナ内に開発環境を構築できるようにする。

Close #48

## 変更内容

- `Dockerfile`: ubuntu:24.04 ベースで全モジュールをプリインストール
- `docker-compose.yml`: `.env` ファイルで API キーを注入、ワークスペースマウント
- `.devcontainer/devcontainer.json`: VS Code / Cursor から接続可能な Dev Container 設定
- `.env.example`: API キーのテンプレート
- `.dockerignore`: ビルドコンテキストの最適化
- `README.md`: Docker セクションとディレクトリ構成を追加

## コンテナに含まれるツール

- Zsh + Zinit + Powerlevel10k
- Git グローバル設定
- モダン CLI ツール (eza, bat, fd, ripgrep)
- Node.js (fnm + LTS)
- Claude Code
- Python (pyenv)
- Gemini CLI

## テスト

- [x] `docker compose build` が成功すること
- [x] コンテナ内で全ツール (node, claude, eza, pyenv, fnm) が利用可能であること
- [x] 非 root ユーザー (`dev`) で動作すること