### PR TITLE
feat: 1Password サービスアカウントトークン保存機能

### DIFF
--- a/dotfiles/.zsh/1password.zsh
+++ b/dotfiles/.zsh/1password.zsh
@@ -10,16 +10,16 @@
 
 # --- 1Password Service Account Token ---
 # NOTE: Independent of ENABLE_SSH_1PASSWORD — always load if the file exists
-if [[ -r "${HOME}/.config/op/service-account-token" ]]; then
+if [[ -r "${HOME}/.config/op/.env" ]]; then
     # Validate file permissions (warn if not 600)
-    _op_token_perms=$(command stat -c '%a' "${HOME}/.config/op/service-account-token" 2>/dev/null \
-        || command stat -f '%Lp' "${HOME}/.config/op/service-account-token" 2>/dev/null)
+    _op_token_perms=$(command stat -c '%a' "${HOME}/.config/op/.env" 2>/dev/null \
+        || command stat -f '%Lp' "${HOME}/.config/op/.env" 2>/dev/null)
     if [[ "$_op_token_perms" != "600" ]]; then
-        print -P "%F{220}警告: ${HOME}/.config/op/service-account-token のパーミッションが ${_op_token_perms} です (推奨: 600)。%f" >&2
+        print -P "%F{220}警告: ${HOME}/.config/op/.env のパーミッションが ${_op_token_perms} です (推奨: 600)。%f" >&2
     fi
     unset _op_token_perms
     # Validate file contains only the expected export line before sourcing
-    _op_token_file="${HOME}/.config/op/service-account-token"
+    _op_token_file="${HOME}/.config/op/.env"
     if grep -qxE "export OP_SERVICE_ACCOUNT_TOKEN='[A-Za-z0-9_+/=.-]+'" "$_op_token_file"; then
         source "$_op_token_file"
     else

--- a/dotfiles/.zsh/1password.zsh
+++ b/dotfiles/.zsh/1password.zsh
@@ -8,6 +8,26 @@
 # 有効化: export ENABLE_SSH_1PASSWORD=1 を .zshenv 等で設定
 # ----------------------------
 
+# --- 1Password Service Account Token ---
+# NOTE: Independent of ENABLE_SSH_1PASSWORD — always load if the file exists
+if [[ -r "${HOME}/.config/op/service-account-token" ]]; then
+    # Validate file permissions (warn if not 600)
+    _op_token_perms=$(command stat -c '%a' "${HOME}/.config/op/service-account-token" 2>/dev/null \
+        || command stat -f '%Lp' "${HOME}/.config/op/service-account-token" 2>/dev/null)
+    if [[ "$_op_token_perms" != "600" ]]; then
+        print -P "%F{220}警告: ${HOME}/.config/op/service-account-token のパーミッションが ${_op_token_perms} です (推奨: 600)。%f" >&2
+    fi
+    unset _op_token_perms
+    # Validate file contains only the expected export line before sourcing
+    _op_token_file="${HOME}/.config/op/service-account-token"
+    if grep -qxE "export OP_SERVICE_ACCOUNT_TOKEN='[A-Za-z0-9_+/=.-]+'" "$_op_token_file"; then
+        source "$_op_token_file"
+    else
+        print -P "%F{196}[1password] トークンファイルの内容が不正です: $_op_token_file%f" >&2
+    fi
+    unset _op_token_file
+fi
+
 if [[ "${ENABLE_SSH_1PASSWORD:-0}" != "1" ]]; then
     return 0 2>/dev/null || true
 fi

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -13,7 +13,7 @@ MODULE_ORDER=13
 # NOTE: モジュール固有の変数には衝突回避のため OP_MOD_ プレフィックスを使用
 OP_MOD_DEBSIG_KEY_ID="AC2D62742012EA22"
 OP_MOD_TOKEN_DIR="${HOME}/.config/op"
-OP_MOD_TOKEN_FILE="${OP_MOD_TOKEN_DIR}/service-account-token"
+OP_MOD_TOKEN_FILE="${OP_MOD_TOKEN_DIR}/.env"
 
 # 管理対象ファイル（配布元パス, 配置先パス, 表示名, 未検出時メッセージ）
 OP_MOD_MANAGED_FILES=(

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -12,6 +12,8 @@ MODULE_ORDER=13
 
 # NOTE: モジュール固有の変数には衝突回避のため OP_MOD_ プレフィックスを使用
 OP_MOD_DEBSIG_KEY_ID="AC2D62742012EA22"
+OP_MOD_TOKEN_DIR="${HOME}/.config/op"
+OP_MOD_TOKEN_FILE="${OP_MOD_TOKEN_DIR}/service-account-token"
 
 # 管理対象ファイル（配布元パス, 配置先パス, 表示名, 未検出時メッセージ）
 OP_MOD_MANAGED_FILES=(
@@ -265,6 +267,113 @@ _1password_setup_git_signing() {
     fi
 }
 
+# --- Helper: Service account token storage ---
+_1password_setup_service_account_token() {
+    print -P ""
+    print -P "サービスアカウントトークン設定:"
+
+    # Check if token file already exists
+    if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
+        print -P "  情報: トークンファイルが既に存在します (${OP_MOD_TOKEN_FILE})。"
+        print -P -n "  上書きしますか？ [y/N]: "
+        local overwrite
+        read -r overwrite
+        if [[ "$overwrite" != [yY] ]]; then
+            print -P "  スキップしました。"
+            return 0
+        fi
+    else
+        print -P -n "  サービスアカウントトークンを設定しますか？ [y/N]: "
+        local configure
+        read -r configure
+        if [[ "$configure" != [yY] ]]; then
+            print -P "  スキップしました。"
+            return 0
+        fi
+    fi
+
+    # Prompt for token value (silent input)
+    print -P -n "  トークンを入力してください: "
+    local token
+    read -r -s token
+    print ""  # Newline after silent input
+
+    if [[ -z "$token" ]]; then
+        print -P "  %F{220}警告: トークンが空です。スキップします。%f"
+        return 0
+    fi
+
+    # Validate token characters (allow only safe characters to prevent injection)
+    if [[ ! "$token" =~ ^[A-Za-z0-9_+/=.-]+$ ]]; then
+        print -P "%F{196}エラー: トークンに不正な文字が含まれています。%f"
+        return 1
+    fi
+
+    # Warn if token seems too short
+    if (( ${#token} < 10 )); then
+        print -P "%F{220}警告: トークンが短すぎます。正しい値か確認してください。%f"
+    fi
+
+    # Create directory with restricted permissions
+    if [[ ! -d "$OP_MOD_TOKEN_DIR" ]]; then
+        if (( DRY_RUN )); then
+            print -P "%F{242}  [DRY-RUN] mkdir -p ${OP_MOD_TOKEN_DIR} && chmod 700 ${OP_MOD_TOKEN_DIR}%f"
+        else
+            mkdir -p "$OP_MOD_TOKEN_DIR" || {
+                print -P "%F{160}エラー: ${OP_MOD_TOKEN_DIR} の作成に失敗しました。%f" >&2
+                return 1
+            }
+            chmod 700 "$OP_MOD_TOKEN_DIR" || {
+                print -P "%F{160}エラー: ${OP_MOD_TOKEN_DIR} のパーミッション設定に失敗しました。%f" >&2
+                return 1
+            }
+        fi
+    fi
+
+    # Write token file with restricted permissions
+    if (( DRY_RUN )); then
+        print -P "%F{242}  [DRY-RUN] トークンを ${OP_MOD_TOKEN_FILE} に保存 (chmod 600)%f"
+    else
+        # Write the token file atomically via a temp file
+        # Set restrictive umask so mktemp creates files with safe permissions
+        local old_umask
+        old_umask=$(umask)
+        umask 077
+
+        local tmp_file
+        tmp_file=$(mktemp "${OP_MOD_TOKEN_DIR}/.token.XXXXXX") || {
+            print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+            umask "$old_umask"
+            return 1
+        }
+
+        chmod 600 "$tmp_file" || {
+            print -P "%F{160}エラー: 一時ファイルのパーミッション設定に失敗しました。%f" >&2
+            rm -f "$tmp_file"
+            umask "$old_umask"
+            return 1
+        }
+
+        printf "export OP_SERVICE_ACCOUNT_TOKEN='%s'\n" "$token" > "$tmp_file" || {
+            print -P "%F{160}エラー: トークンの書き込みに失敗しました。%f" >&2
+            rm -f "$tmp_file"
+            umask "$old_umask"
+            return 1
+        }
+
+        mv "$tmp_file" "$OP_MOD_TOKEN_FILE" || {
+            print -P "%F{160}エラー: トークンファイルの配置に失敗しました。%f" >&2
+            rm -f "$tmp_file"
+            umask "$old_umask"
+            return 1
+        }
+
+        umask "$old_umask"
+
+        print -P "  %F{34}トークンを保存しました: ${OP_MOD_TOKEN_FILE}%f"
+    fi
+}
+
 # --- セットアップ ---
 module_setup() {
     print -P ""
@@ -334,6 +443,9 @@ module_setup() {
     # --- 4. Git コミット署名設定 ---
     _1password_setup_git_signing "$env"
 
+    # --- 5. サービスアカウントトークン設定 ---
+    _1password_setup_service_account_token
+
     # --- 完了メッセージ ---
     print -P ""
     if (( DRY_RUN )); then
@@ -373,6 +485,35 @@ module_uninstall() {
                 fi
             fi
             restored=1
+        fi
+    fi
+
+    # サービスアカウントトークンの削除
+    if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
+        print -P -n "サービスアカウントトークンを削除しますか？ (${OP_MOD_TOKEN_FILE}) [y/N]: "
+        local remove_token
+        read -r remove_token
+        if [[ "$remove_token" == [yY] ]]; then
+            if (( DRY_RUN )); then
+                print -P "%F{242}  [DRY-RUN] rm -f ${OP_MOD_TOKEN_FILE}%f"
+            else
+                # Use shred for secure deletion if available
+                if command -v shred >/dev/null 2>&1; then
+                    shred -u "$OP_MOD_TOKEN_FILE" || {
+                        print -P "%F{160}エラー: トークンファイルの安全な削除に失敗しました。%f" >&2
+                        return 1
+                    }
+                else
+                    rm -f "$OP_MOD_TOKEN_FILE" || {
+                        print -P "%F{160}エラー: トークンファイルの削除に失敗しました。%f" >&2
+                        return 1
+                    }
+                fi
+                print -P "情報: サービスアカウントトークンを削除しました。"
+            fi
+            restored=1
+        else
+            print -P "情報: トークンファイルは残しました。手動で削除する場合: rm ${OP_MOD_TOKEN_FILE}"
         fi
     fi
 


### PR DESCRIPTION
## Summary
- サービスアカウントトークンを `~/.config/op/.env` に安全に保存する機能を追加
- セキュリティ対策: 入力値ホワイトリスト検証、シングルクォート出力、umask 077、アトミック書き込み、shred による安全な削除
- `1password.zsh` で source 前に grep -qxE によるファイル内容検証を実施

## Test plan
- [ ] DRY_RUN モードでトークン保存フローを確認
- [ ] トークン保存後にファイルパーミッション (600) を確認
- [ ] 不正文字を含むトークン入力時にバリデーションが機能することを確認
- [ ] `module_uninstall()` でトークンファイルが削除されることを確認