### PR TITLE
fix: バックアップ復元ソート修正 & ensure_node バージョン引数追加

### DIFF
--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -523,7 +523,7 @@ module_uninstall() {
         local label="${entry[(ws:|:)3]}"
 
         local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/om[1]) )
+        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
 
         if (( ${#latest_backup[@]} > 0 )); then
             print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -53,7 +53,7 @@ module_setup() {
         print -P "情報: Gemini CLI は既にインストールされています (${current_ver})。スキップします。"
     else
         # Node.js / npm の確認
-        if ! ensure_node; then
+        if ! ensure_node 20; then
             print -P "%F{220}スキップ: Gemini CLI のインストールには Node.js v20+ が必要です。%f"
             return 1
         fi

--- a/dotfiles/modules/git.sh
+++ b/dotfiles/modules/git.sh
@@ -183,7 +183,7 @@ module_uninstall() {
         local label="${entry[(ws:|:)3]}"
 
         local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/om[1]) )
+        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
 
         if (( ${#latest_backup[@]} > 0 )); then
             print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -288,7 +288,7 @@ module_uninstall() {
         local label="${entry[(ws:|:)3]}"
 
         local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/om[1]) )
+        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
 
         if (( ${#latest_backup[@]} > 0 )); then
             print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -193,7 +193,7 @@ module_uninstall() {
         local label="${entry[(ws:|:)3]}"
 
         local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/om[1]) )
+        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
 
         if (( ${#latest_backup[@]} > 0 )); then
             print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -98,7 +98,7 @@ module_uninstall() {
 
         # Zsh Glob 限定子で最新のバックアップを検索（シンボリックリンクも含む、ディレクトリは除外）
         local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/om[1]) )
+        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
 
         if (( ${#latest_backup[@]} > 0 )); then
             print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -136,20 +136,23 @@ install_config() {
     fi
 }
 
-# Node.js v18+ と npm の存在を確認するヘルパー
+# Node.js と npm の存在を確認するヘルパー
+# 引数: $1=最低メジャーバージョン（省略時: 18）
 # 戻り値: 0=利用可能, 1=利用不可
 ensure_node() {
+    local min_version="${1:-18}"
+
     if ! command -v node >/dev/null 2>&1; then
         print -P "%F{160}エラー: Node.js がインストールされていません。%f" >&2
-        print -P "  nvm, fnm, volta 等で Node.js v18 以上をインストールしてください。" >&2
+        print -P "  nvm, fnm, volta 等で Node.js v${min_version} 以上をインストールしてください。" >&2
         print -P "  例: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash" >&2
         return 1
     fi
 
     local node_ver
     node_ver=$(node -v | sed 's/^v//' | cut -d. -f1)
-    if (( node_ver < 18 )); then
-        print -P "%F{160}エラー: Node.js v18 以上が必要です（現在: v${node_ver}）%f" >&2
+    if (( node_ver < min_version )); then
+        print -P "%F{160}エラー: Node.js v${min_version} 以上が必要です（現在: v${node_ver}）%f" >&2
         print -P "  Node.js をアップグレードしてください。" >&2
         return 1
     fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -151,6 +151,17 @@ ensure_node() {
 
     local node_ver
     node_ver=$(node -v | sed 's/^v//' | cut -d. -f1)
+
+    # Validate numeric values
+    if [[ ! "$min_version" =~ ^[0-9]+$ ]]; then
+        print -P "%F{160}エラー: ensure_node に不正な引数が渡されました: ${min_version}%f" >&2
+        return 1
+    fi
+    if [[ ! "$node_ver" =~ ^[0-9]+$ ]]; then
+        print -P "%F{160}エラー: Node.js のバージョンを取得できませんでした。%f" >&2
+        return 1
+    fi
+
     if (( node_ver < min_version )); then
         print -P "%F{160}エラー: Node.js v${min_version} 以上が必要です（現在: v${node_ver}）%f" >&2
         print -P "  Node.js をアップグレードしてください。" >&2


### PR DESCRIPTION
## 概要

2つのバグ修正をまとめた PR。

Close #59, Close #60

## 変更内容

### #59: バックアップ復元のグロブソートを最新優先に修正

5モジュール (zsh, git, node, python, 1password) のアンインストール時、バックアップ復元で `om[1]`（最古優先）を使用していたのを `Om[1]`（最新優先）に修正。

**変更ファイル**: `dotfiles/modules/{zsh,git,node,python,1password}.sh`

### #60: ensure_node() に最小バージョン引数を追加

`ensure_node()` がオプショナルな最小バージョンパラメータを受け取るように変更。Gemini CLI は Node.js v20+ が必要だが、従来の v18 チェックでは検出できなかった。

- `ensure_node()`: デフォルト v18、引数でバージョン指定可能に
- `gemini-cli.sh`: `ensure_node 20` に変更
- `claude-code.sh`, `codex-cli.sh`: デフォルト (v18) のまま維持

**変更ファイル**: `dotfiles/setup.sh`, `dotfiles/modules/gemini-cli.sh`

## テスト計画

- [x] 全変更ファイルの zsh 構文チェック通過
- [ ] アンインストール時に最新のバックアップが復元されることを確認
- [ ] Node.js v18 環境で Gemini CLI インストール時にエラーが出ることを確認
- [ ] Node.js v20+ 環境で Gemini CLI が正常にインストールできることを確認