### PR TITLE
refactor: スクリプト層を zsh から bash に移行 (Phase 1)

### DIFF
--- a/dotfiles/lib/array.sh
+++ b/dotfiles/lib/array.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Array utility helpers for bash
+# Replaces zsh array operations: ${(Ie)}, ${(o)}, ${(s:...:)}
+
+# Check if value exists in array
+# Usage: array_contains "value" "${array[@]}"
+# Returns: 0 if found, 1 if not
+array_contains() {
+    local needle="$1"
+    shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# Sort array ascending (newline-safe)
+# Usage: array_sort sorted_var "${array[@]}"
+array_sort() {
+    local -n _result="$1"
+    shift
+    readarray -t _result < <(printf '%s\n' "$@" | sort)
+}
+
+# Sort array descending
+# Usage: array_sort_desc sorted_var "${array[@]}"
+array_sort_desc() {
+    local -n _result="$1"
+    shift
+    readarray -t _result < <(printf '%s\n' "$@" | sort -r)
+}
+
+# Split string by delimiter into array
+# Usage: string_split result_var "delimiter" "string"
+string_split() {
+    local -n _result="$1"
+    local delimiter="$2" string="$3"
+    local old_ifs="$IFS"
+    IFS="$delimiter" read -ra _result <<< "$string"
+    IFS="$old_ifs"
+}

--- a/dotfiles/lib/backup.sh
+++ b/dotfiles/lib/backup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Backup file helpers
+# Replaces zsh glob qualifiers: *(N^/Om[1])
+
+# Find the newest backup file matching a pattern
+# Usage: find_newest_backup "/path/to/file.bak.*"
+# Returns: path to newest backup (stdout), or empty + return 1
+find_newest_backup() {
+    local pattern="$1"
+    local newest
+    # Use ls -t for modification-time sort (newest first)
+    # Redirect stderr to hide "no matches" errors
+    newest=$(ls -t $pattern 2>/dev/null | head -1)
+    if [[ -n "$newest" ]]; then
+        printf '%s' "$newest"
+        return 0
+    fi
+    return 1
+}
+
+# Create a timestamped backup of a file
+# Usage: create_backup "/path/to/file"
+# Returns: backup path (stdout)
+create_backup() {
+    local file="$1"
+    local backup="${file}.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$file" "$backup"
+    printf '%s' "$backup"
+}

--- a/dotfiles/lib/backup.sh
+++ b/dotfiles/lib/backup.sh
@@ -10,7 +10,7 @@ find_newest_backup() {
     local newest
     # Use ls -t for modification-time sort (newest first)
     # Redirect stderr to hide "no matches" errors
-    newest=$(ls -t $pattern 2>/dev/null | head -1)
+    newest=$(ls -t $pattern 2>/dev/null | head -1 || true)
     if [[ -n "$newest" ]]; then
         printf '%s' "$newest"
         return 0

--- a/dotfiles/lib/colors.sh
+++ b/dotfiles/lib/colors.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Color output helpers for setup scripts
+# Replaces zsh print -P "%F{N}..." pattern with bash ANSI equivalents
+
+# Initialize color variables (call once at script start)
+# Respects NO_COLOR standard and TTY detection
+_setup_colors() {
+    if [[ -n "${NO_COLOR:-}" ]] || [[ ! -t 1 ]]; then
+        C_RESET="" C_BOLD="" C_BOLD_OFF="" C_DIM=""
+        C_RED="" C_GREEN="" C_YELLOW="" C_CYAN="" C_GRAY=""
+    else
+        C_RESET=$'\e[0m'
+        C_BOLD=$'\e[1m'
+        C_BOLD_OFF=$'\e[22m'
+        C_DIM=$'\e[2m'
+        # Match zsh %F{N} color numbers
+        C_RED=$'\e[38;5;160m'       # %F{160}
+        C_GREEN=$'\e[38;5;34m'      # %F{34}
+        C_YELLOW=$'\e[38;5;220m'    # %F{220}
+        C_CYAN=$'\e[38;5;36m'       # %F{36}
+        C_GRAY=$'\e[38;5;242m'      # %F{242}
+    fi
+}
+
+# Message helpers
+msg_error()   { printf '%s%sエラー: %s%s\n' "${C_RED}" "${C_BOLD}" "$1" "${C_RESET}" >&2; }
+msg_warn()    { printf '%s警告: %s%s\n' "${C_YELLOW}" "$1" "${C_RESET}"; }
+msg_info()    { printf '情報: %s\n' "$1"; }
+msg_success() { printf '%s%s%s\n' "${C_GREEN}" "$1" "${C_RESET}"; }
+msg_header()  { printf '\n%s%s[%s]%s\n' "${C_CYAN}" "${C_BOLD}" "$1" "${C_RESET}"; }
+msg_dry_run() { printf '%s  [DRY-RUN] %s%s\n' "${C_GRAY}" "$1" "${C_RESET}"; }
+msg_step()    { printf '  %s\n' "$1"; }
+
+# Formatted output (for custom color needs)
+# Usage: color_print "$C_RED" "text"
+color_print() {
+    local color="$1" text="$2"
+    printf '%s%s%s\n' "$color" "$text" "${C_RESET}"
+}
+
+# Print separator line
+print_separator() {
+    printf '%s\n' "---------------------------------------------"
+}

--- a/dotfiles/lib/tui.sh
+++ b/dotfiles/lib/tui.sh
@@ -112,6 +112,11 @@ _cb_draw() {
 #   0 = confirmed (Enter)
 #   1 = cancelled (q)
 checkbox_menu() {
+    if [[ $# -lt 2 ]]; then
+        msg_error "checkbox_menu: 引数が不足しています (プロンプト + 1つ以上の項目が必要)"
+        return 1
+    fi
+
     _CB_PROMPT="$1"
     shift
 
@@ -155,7 +160,7 @@ checkbox_menu() {
     local key
     while true; do
         # Read single character (silent, raw)
-        IFS= read -rsn1 key
+        IFS= read -rsn1 key || { _cb_cleanup; return 1; }
 
         case "$key" in
             $'\e')

--- a/dotfiles/lib/tui.sh
+++ b/dotfiles/lib/tui.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# TUI checkbox menu for module selection
+# Replaces zsh checkbox_menu() with bash-compatible implementation
+#
+# Dependencies: lib/colors.sh (_setup_colors, $C_CYAN, $C_BOLD, etc.)
+#
+# Usage:
+#   checkbox_menu "Select modules:" "Name1|Desc1|1" "Name2|Desc2|0" ...
+#   echo "$REPLY"  # => "0 2" (space-separated 0-based indices)
+
+# Guard: only source colors.sh if _setup_colors is not yet defined
+if ! declare -f _setup_colors >/dev/null 2>&1; then
+    _TUI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=./colors.sh
+    source "${_TUI_DIR}/colors.sh"
+    _setup_colors
+fi
+
+# --- Internal state (module-level) ---
+# These are set by checkbox_menu and used by _cb_draw / _cb_cleanup.
+declare -a _CB_LABELS=()
+declare -a _CB_DESCS=()
+declare -a _CB_SELECTED=()
+declare -i _CB_COUNT=0
+declare -i _CB_CURSOR=0
+declare -i _CB_HEADER_LINES=2
+declare -i _CB_TOTAL_LINES=0
+
+# Cleanup handler: restore terminal state on interrupt/exit
+_cb_cleanup() {
+    # Show cursor
+    printf '\e[?25h'
+    # Reset all attributes
+    printf '\e[0m'
+    printf '\n'
+    exit 130
+}
+
+# Prompt text stored for _cb_draw
+declare _CB_PROMPT=""
+
+# Draw the menu (internal)
+# Arguments: $1 = 1 if redrawing (move cursor up first)
+_cb_draw() {
+    local redraw="${1:-0}"
+    local max_width="${COLUMNS:-80}"
+
+    # On redraw, move cursor up to start of menu
+    if (( redraw )); then
+        printf '\e[%dA' "$_CB_TOTAL_LINES"
+    fi
+
+    # Header
+    printf '\e[2K'  # Clear line
+    printf '%s%s %s %s\n' \
+        "${C_CYAN}" "${C_BOLD}" "$_CB_PROMPT" "${C_RESET}"
+    printf '\e[2K'  # Clear line
+    printf '%s (up/down:move  Space:toggle  a:all  n:none  Enter:confirm  q:cancel)%s\n' \
+        "${C_GRAY}" "${C_RESET}"
+
+    # Menu items
+    local i
+    for (( i = 0; i < _CB_COUNT; i++ )); do
+        printf '\e[2K'  # Clear line
+
+        local prefix="  "
+        local check="[ ]"
+
+        if (( _CB_SELECTED[i] )); then
+            check="[x]"
+        fi
+
+        if (( i == _CB_CURSOR )); then
+            prefix="> "
+        fi
+
+        # Build display line
+        local label="${_CB_LABELS[$i]}"
+        local desc="${_CB_DESCS[$i]}"
+
+        # Pad label to fixed width for alignment
+        local label_width=20
+        local padded_label
+        padded_label=$(printf '%-*s' "$label_width" "$label")
+
+        local line="${prefix}${check} ${padded_label} ${desc}"
+
+        # Truncate to terminal width
+        if (( ${#line} > max_width - 1 )); then
+            line="${line:0:$((max_width - 2))}"
+        fi
+
+        if (( i == _CB_CURSOR )); then
+            # Reverse video (highlighted)
+            printf '\e[7m%s\e[0m\n' "$line"
+        else
+            printf '%s\n' "$line"
+        fi
+    done
+}
+
+# Checkbox menu: display interactive selection UI
+#
+# Arguments:
+#   $1        - prompt text displayed in the header line
+#   $2..$N    - menu items in "name|description|default(0/1)" format
+#
+# Sets:
+#   REPLY     - space-separated list of selected indices (0-based)
+#
+# Returns:
+#   0 = confirmed (Enter)
+#   1 = cancelled (q)
+checkbox_menu() {
+    _CB_PROMPT="$1"
+    shift
+
+    # Parse items
+    _CB_COUNT=$#
+    _CB_LABELS=()
+    _CB_DESCS=()
+    _CB_SELECTED=()
+    _CB_CURSOR=0
+    _CB_HEADER_LINES=2
+    _CB_TOTAL_LINES=$(( _CB_HEADER_LINES + _CB_COUNT ))
+
+    local item label desc default_val i
+    for item in "$@"; do
+        # Split by pipe delimiter
+        IFS='|' read -r label desc default_val <<< "$item"
+
+        _CB_LABELS+=("$label")
+        _CB_DESCS+=("$desc")
+        _CB_SELECTED+=("${default_val:-0}")
+    done
+
+    # Set up signal handlers for clean exit
+    trap '_cb_cleanup' INT TERM QUIT
+
+    # Hide cursor
+    printf '\e[?25h'  # Ensure visible first (reset state)
+    printf '\e[?25l'  # Then hide
+
+    # Reserve vertical space by printing blank lines, then move back up
+    local j
+    for (( j = 0; j < _CB_TOTAL_LINES; j++ )); do
+        printf '\n'
+    done
+    printf '\e[%dA' "$_CB_TOTAL_LINES"
+
+    # Initial draw
+    _cb_draw 0
+
+    # Input loop
+    local key
+    while true; do
+        # Read single character (silent, raw)
+        IFS= read -rsn1 key
+
+        case "$key" in
+            $'\e')
+                # Escape sequence: read remaining bytes for arrow keys
+                local key2="" key3=""
+                IFS= read -rsn1 -t 0.1 key2 2>/dev/null || true
+                if [[ "$key2" == "[" || "$key2" == "O" ]]; then
+                    IFS= read -rsn1 -t 0.1 key3 2>/dev/null || true
+                    case "$key3" in
+                        A)  # Up arrow
+                            if (( _CB_CURSOR > 0 )); then _CB_CURSOR=$(( _CB_CURSOR - 1 )); fi
+                            ;;
+                        B)  # Down arrow
+                            if (( _CB_CURSOR < _CB_COUNT - 1 )); then _CB_CURSOR=$(( _CB_CURSOR + 1 )); fi
+                            ;;
+                    esac
+                fi
+                ;;
+            k)  # vim: up
+                if (( _CB_CURSOR > 0 )); then _CB_CURSOR=$(( _CB_CURSOR - 1 )); fi
+                ;;
+            j)  # vim: down
+                if (( _CB_CURSOR < _CB_COUNT - 1 )); then _CB_CURSOR=$(( _CB_CURSOR + 1 )); fi
+                ;;
+            ' ')  # Space: toggle selection
+                if (( _CB_SELECTED[_CB_CURSOR] )); then
+                    _CB_SELECTED[$_CB_CURSOR]=0
+                else
+                    _CB_SELECTED[$_CB_CURSOR]=1
+                fi
+                ;;
+            a)  # Select all
+                for (( i = 0; i < _CB_COUNT; i++ )); do
+                    _CB_SELECTED[$i]=1
+                done
+                ;;
+            n)  # Deselect all
+                for (( i = 0; i < _CB_COUNT; i++ )); do
+                    _CB_SELECTED[$i]=0
+                done
+                ;;
+            q)  # Cancel
+                printf '\e[?25h'  # Show cursor
+                trap - INT TERM QUIT
+                return 1
+                ;;
+            '')  # Enter key (read -n1 returns empty string for newline)
+                break
+                ;;
+        esac
+
+        # Redraw
+        _cb_draw 1
+    done
+
+    # Restore terminal state
+    printf '\e[?25h'  # Show cursor
+    trap - INT TERM QUIT
+
+    # Build result: space-separated list of selected 0-based indices
+    REPLY=""
+    for (( i = 0; i < _CB_COUNT; i++ )); do
+        if (( _CB_SELECTED[i] )); then
+            if [[ -n "$REPLY" ]]; then
+                REPLY+=" "
+            fi
+            REPLY+="$i"
+        fi
+    done
+
+    return 0
+}

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -25,36 +25,36 @@ OP_MOD_MANAGED_FILES=(
 _1password_detect_env() {
     case "$OSTYPE" in
         darwin*)
-            print "macos"
+            printf '%s' "macos"
             ;;
         linux*)
             if [[ -f /proc/version ]] && grep -qi 'microsoft' /proc/version 2>/dev/null; then
-                print "wsl"
+                printf '%s' "wsl"
             else
-                print "linux"
+                printf '%s' "linux"
             fi
             ;;
         *)
-            print "unknown"
+            printf '%s' "unknown"
             ;;
     esac
 }
 
 # --- ヘルパー: op CLI のインストール (Ubuntu/Debian) ---
 _1password_install_op_apt() {
-    print -P "  1Password CLI の apt リポジトリを設定します..."
+    msg_step "1Password CLI の apt リポジトリを設定します..."
 
     # 前提コマンドの確認
     local -a required_cmds=(curl gpg)
     for cmd in "${required_cmds[@]}"; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
-            print -P "%F{160}エラー: ${cmd} がインストールされていません。%f" >&2
+            msg_error "${cmd} がインストールされていません。"
             return 1
         fi
     done
 
     run_cmd sudo mkdir -p /etc/apt/keyrings || {
-        print -P "%F{160}エラー: /etc/apt/keyrings の作成に失敗しました。%f" >&2
+        msg_error "/etc/apt/keyrings の作成に失敗しました。"
         return 1
     }
 
@@ -62,12 +62,12 @@ _1password_install_op_apt() {
         # GPG キーのダウンロードと変換を分離して個別にエラーチェック
         local tmp_key
         tmp_key=$(mktemp) || {
-            print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+            msg_error "一時ファイルの作成に失敗しました。"
             return 1
         }
 
         if ! curl -sS -o "$tmp_key" https://downloads.1password.com/linux/keys/1password.asc; then
-            print -P "%F{160}エラー: 1Password の GPG キー取得に失敗しました。%f" >&2
+            msg_error "1Password の GPG キー取得に失敗しました。"
             rm -f "$tmp_key"
             return 1
         fi
@@ -76,15 +76,15 @@ _1password_install_op_apt() {
         [[ -f /etc/apt/keyrings/1password-archive-keyring.gpg ]] && sudo rm -f /etc/apt/keyrings/1password-archive-keyring.gpg
 
         sudo gpg --dearmor --output /etc/apt/keyrings/1password-archive-keyring.gpg "$tmp_key" 2>/dev/null || {
-            print -P "%F{160}エラー: GPG キー変換に失敗しました。%f" >&2
+            msg_error "GPG キー変換に失敗しました。"
             rm -f "$tmp_key"
             return 1
         }
 
         # apt ソースの追加
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+        printf '%s\n' "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
             | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null || {
-            print -P "%F{160}エラー: 1Password の apt ソース追加に失敗しました。%f" >&2
+            msg_error "1Password の apt ソース追加に失敗しました。"
             rm -f "$tmp_key"
             return 1
         }
@@ -92,35 +92,35 @@ _1password_install_op_apt() {
         # debsig ポリシーの設定
         run_cmd sudo mkdir -p "/etc/debsig/policies/${OP_MOD_DEBSIG_KEY_ID}/"
         if ! curl -sS -o "$tmp_key" https://downloads.1password.com/linux/debian/debsig/1password.pol; then
-            print -P "%F{220}警告: debsig ポリシーのダウンロードに失敗しました（インストールは継続します）。%f"
+            msg_warn "debsig ポリシーのダウンロードに失敗しました（インストールは継続します）。"
         else
             sudo tee /etc/debsig/policies/${OP_MOD_DEBSIG_KEY_ID}/1password.pol < "$tmp_key" >/dev/null || {
-                print -P "%F{220}警告: debsig ポリシーの設定に失敗しました（インストールは継続します）。%f"
+                msg_warn "debsig ポリシーの設定に失敗しました（インストールは継続します）。"
             }
         fi
 
         run_cmd sudo mkdir -p "/usr/share/debsig/keyrings/${OP_MOD_DEBSIG_KEY_ID}"
         [[ -f /usr/share/debsig/keyrings/${OP_MOD_DEBSIG_KEY_ID}/debsig.gpg ]] && sudo rm -f /usr/share/debsig/keyrings/${OP_MOD_DEBSIG_KEY_ID}/debsig.gpg
         if ! curl -sS -o "$tmp_key" https://downloads.1password.com/linux/keys/1password.asc; then
-            print -P "%F{220}警告: debsig キーリング用キーの取得に失敗しました（インストールは継続します）。%f"
+            msg_warn "debsig キーリング用キーの取得に失敗しました（インストールは継続します）。"
         else
             sudo gpg --dearmor --output /usr/share/debsig/keyrings/${OP_MOD_DEBSIG_KEY_ID}/debsig.gpg "$tmp_key" 2>/dev/null || {
-                print -P "%F{220}警告: debsig キーリングの設定に失敗しました（インストールは継続します）。%f"
+                msg_warn "debsig キーリングの設定に失敗しました（インストールは継続します）。"
             }
         fi
 
         rm -f "$tmp_key"
     else
-        print -P "%F{242}  [DRY-RUN] curl ... | sudo gpg --dearmor -o /etc/apt/keyrings/1password-archive-keyring.gpg%f"
-        print -P "%F{242}  [DRY-RUN] echo 'deb ...' | sudo tee /etc/apt/sources.list.d/1password.list%f"
-        print -P "%F{242}  [DRY-RUN] debsig ポリシー設定%f"
+        msg_dry_run "curl ... | sudo gpg --dearmor -o /etc/apt/keyrings/1password-archive-keyring.gpg"
+        msg_dry_run "echo 'deb ...' | sudo tee /etc/apt/sources.list.d/1password.list"
+        msg_dry_run "debsig ポリシー設定"
     fi
 
     run_cmd sudo apt-get update -qq || {
-        print -P "%F{220}警告: apt update に失敗しました。%f"
+        msg_warn "apt update に失敗しました。"
     }
     run_cmd sudo apt-get install -y 1password-cli || {
-        print -P "%F{160}エラー: 1Password CLI のインストールに失敗しました。%f" >&2
+        msg_error "1Password CLI のインストールに失敗しました。"
         return 1
     }
 }
@@ -128,7 +128,7 @@ _1password_install_op_apt() {
 # --- ヘルパー: op CLI のインストール (macOS) ---
 _1password_install_op_brew() {
     run_cmd brew install --cask 1password-cli || {
-        print -P "%F{160}エラー: 1Password CLI のインストールに失敗しました。%f" >&2
+        msg_error "1Password CLI のインストールに失敗しました。"
         return 1
     }
 }
@@ -137,45 +137,45 @@ _1password_install_op_brew() {
 _1password_setup_ssh_agent() {
     local env="$1"
 
-    print -P ""
-    print -P "SSH エージェント設定:"
+    printf '\n'
+    printf '%s\n' "SSH エージェント設定:"
 
     case "$env" in
         wsl)
-            print -P "  WSL 環境を検出しました。"
-            print -P "  Windows 側の 1Password デスクトップアプリで SSH エージェントを有効にしてください。"
-            print -P "  1password.zsh により ssh/ssh-add が Windows 側にリダイレクトされます。"
-            print -P ""
-            print -P "  有効化:"
-            print -P "    export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
+            msg_step "WSL 環境を検出しました。"
+            msg_step "Windows 側の 1Password デスクトップアプリで SSH エージェントを有効にしてください。"
+            msg_step "1password.zsh により ssh/ssh-add が Windows 側にリダイレクトされます。"
+            printf '\n'
+            msg_step "有効化:"
+            msg_step "  export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
             ;;
         linux)
             local sock_path="$HOME/.1password/agent.sock"
-            print -P "  ネイティブ Linux 環境を検出しました。"
+            msg_step "ネイティブ Linux 環境を検出しました。"
             if [[ -S "$sock_path" ]]; then
-                print -P "  %F{34}SSH エージェントソケットが見つかりました。%f"
+                msg_step "$(printf '%s%s%s' "${C_GREEN}" "SSH エージェントソケットが見つかりました。" "${C_RESET}")"
             else
-                print -P "  %F{220}SSH エージェントソケットが見つかりません。%f"
-                print -P "  1Password デスクトップアプリで SSH エージェントを有効にしてください。"
-                print -P "    設定 → 開発者 → SSH エージェント → 有効にする"
+                msg_step "$(printf '%s%s%s' "${C_YELLOW}" "SSH エージェントソケットが見つかりません。" "${C_RESET}")"
+                msg_step "1Password デスクトップアプリで SSH エージェントを有効にしてください。"
+                msg_step "  設定 → 開発者 → SSH エージェント → 有効にする"
             fi
-            print -P ""
-            print -P "  有効化:"
-            print -P "    export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
+            printf '\n'
+            msg_step "有効化:"
+            msg_step "  export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
             ;;
         macos)
             local sock_path="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-            print -P "  macOS 環境を検出しました。"
+            msg_step "macOS 環境を検出しました。"
             if [[ -S "$sock_path" ]]; then
-                print -P "  %F{34}SSH エージェントソケットが見つかりました。%f"
+                msg_step "$(printf '%s%s%s' "${C_GREEN}" "SSH エージェントソケットが見つかりました。" "${C_RESET}")"
             else
-                print -P "  %F{220}SSH エージェントソケットが見つかりません。%f"
-                print -P "  1Password デスクトップアプリで SSH エージェントを有効にしてください。"
-                print -P "    設定 → 開発者 → SSH エージェント → 有効にする"
+                msg_step "$(printf '%s%s%s' "${C_YELLOW}" "SSH エージェントソケットが見つかりません。" "${C_RESET}")"
+                msg_step "1Password デスクトップアプリで SSH エージェントを有効にしてください。"
+                msg_step "  設定 → 開発者 → SSH エージェント → 有効にする"
             fi
-            print -P ""
-            print -P "  有効化:"
-            print -P "    export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
+            printf '\n'
+            msg_step "有効化:"
+            msg_step "  export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
             ;;
     esac
 }
@@ -184,11 +184,11 @@ _1password_setup_ssh_agent() {
 _1password_setup_git_signing() {
     local env="$1"
 
-    print -P ""
-    print -P "Git コミット署名設定:"
+    printf '\n'
+    printf '%s\n' "Git コミット署名設定:"
 
     if ! command -v git >/dev/null 2>&1; then
-        print -P "  %F{220}警告: git が見つかりません。Git 署名設定をスキップします。%f"
+        msg_step "$(printf '%s%s%s' "${C_YELLOW}" "警告: git が見つかりません。Git 署名設定をスキップします。" "${C_RESET}")"
         return 0
     fi
 
@@ -196,16 +196,16 @@ _1password_setup_git_signing() {
     local current_format
     current_format=$(git config --global gpg.format 2>/dev/null || true)
     if [[ "$current_format" == "ssh" ]]; then
-        print -P "  情報: gpg.format は既に ssh に設定されています。"
+        msg_step "情報: gpg.format は既に ssh に設定されています。"
         local current_program
         current_program=$(git config --global gpg.ssh.program 2>/dev/null || true)
         local current_key
         current_key=$(git config --global user.signingkey 2>/dev/null || true)
         local current_sign
         current_sign=$(git config --global commit.gpgsign 2>/dev/null || true)
-        [[ -n "$current_program" ]] && print -P "  gpg.ssh.program: ${current_program}"
-        [[ -n "$current_key" ]] && print -P "  user.signingkey:  ${current_key}"
-        [[ -n "$current_sign" ]] && print -P "  commit.gpgsign:   ${current_sign}"
+        [[ -n "$current_program" ]] && msg_step "gpg.ssh.program: ${current_program}"
+        [[ -n "$current_key" ]] && msg_step "user.signingkey:  ${current_key}"
+        [[ -n "$current_sign" ]] && msg_step "commit.gpgsign:   ${current_sign}"
         return 0
     fi
 
@@ -217,9 +217,9 @@ _1password_setup_git_signing() {
             local win_user
             win_user=$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r')
             if [[ -z "$win_user" ]]; then
-                print -P "  %F{220}警告: Windows ユーザー名を検出できませんでした。%f"
-                print -P "  手動で設定してください:"
-                print -P "    git config --global gpg.ssh.program '/mnt/c/Users/<ユーザー名>/AppData/Local/1Password/app/8/op-ssh-sign.exe'"
+                msg_step "$(printf '%s%s%s' "${C_YELLOW}" "警告: Windows ユーザー名を検出できませんでした。" "${C_RESET}")"
+                msg_step "手動で設定してください:"
+                msg_step "  git config --global gpg.ssh.program '/mnt/c/Users/<ユーザー名>/AppData/Local/1Password/app/8/op-ssh-sign.exe'"
                 return 0
             fi
             sign_program="/mnt/c/Users/${win_user}/AppData/Local/1Password/app/8/op-ssh-sign.exe"
@@ -234,97 +234,97 @@ _1password_setup_git_signing() {
 
     # gpg.format と commit.gpgsign を設定
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] git config --global gpg.format ssh%f"
-        print -P "%F{242}  [DRY-RUN] git config --global gpg.ssh.program ${sign_program}%f"
-        print -P "%F{242}  [DRY-RUN] git config --global commit.gpgsign true%f"
+        msg_dry_run "git config --global gpg.format ssh"
+        msg_dry_run "git config --global gpg.ssh.program ${sign_program}"
+        msg_dry_run "git config --global commit.gpgsign true"
     else
         git config --global gpg.format ssh || {
-            print -P "%F{160}エラー: gpg.format の設定に失敗しました。%f" >&2
+            msg_error "gpg.format の設定に失敗しました。"
             return 1
         }
         git config --global gpg.ssh.program "$sign_program" || {
-            print -P "%F{160}エラー: gpg.ssh.program の設定に失敗しました。%f" >&2
+            msg_error "gpg.ssh.program の設定に失敗しました。"
             return 1
         }
         git config --global commit.gpgsign true || {
-            print -P "%F{160}エラー: commit.gpgsign の設定に失敗しました。%f" >&2
+            msg_error "commit.gpgsign の設定に失敗しました。"
             return 1
         }
-        print -P "  %F{34}Git 署名設定を適用しました。%f"
-        print -P "  gpg.format:       ssh"
-        print -P "  gpg.ssh.program:  ${sign_program}"
-        print -P "  commit.gpgsign:   true"
+        msg_step "$(printf '%s%s%s' "${C_GREEN}" "Git 署名設定を適用しました。" "${C_RESET}")"
+        msg_step "gpg.format:       ssh"
+        msg_step "gpg.ssh.program:  ${sign_program}"
+        msg_step "commit.gpgsign:   true"
     fi
 
     # user.signingkey の案内
     local current_key
     current_key=$(git config --global user.signingkey 2>/dev/null || true)
     if [[ -z "$current_key" ]]; then
-        print -P ""
-        print -P "  %F{220}NOTE: user.signingkey が未設定です。以下を実行してください:%f"
-        print -P "    git config --global user.signingkey \"ssh-ed25519 AAAA...\""
-        print -P "  1Password → SSH キーの詳細 → 公開鍵をコピーして指定してください。"
+        printf '\n'
+        msg_step "$(printf '%s%s%s' "${C_YELLOW}" "NOTE: user.signingkey が未設定です。以下を実行してください:" "${C_RESET}")"
+        msg_step "  git config --global user.signingkey \"ssh-ed25519 AAAA...\""
+        msg_step "1Password → SSH キーの詳細 → 公開鍵をコピーして指定してください。"
     fi
 }
 
 # --- Helper: Service account token storage ---
 _1password_setup_service_account_token() {
-    print -P ""
-    print -P "サービスアカウントトークン設定:"
+    printf '\n'
+    printf '%s\n' "サービスアカウントトークン設定:"
 
     # Check if token file already exists
     if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
-        print -P "  情報: トークンファイルが既に存在します (${OP_MOD_TOKEN_FILE})。"
-        print -P -n "  上書きしますか？ [y/N]: "
+        msg_step "情報: トークンファイルが既に存在します (${OP_MOD_TOKEN_FILE})。"
+        printf '  上書きしますか？ [y/N]: '
         local overwrite
         read -r overwrite
         if [[ "$overwrite" != [yY] ]]; then
-            print -P "  スキップしました。"
+            msg_step "スキップしました。"
             return 0
         fi
     else
-        print -P -n "  サービスアカウントトークンを設定しますか？ [y/N]: "
+        printf '  サービスアカウントトークンを設定しますか？ [y/N]: '
         local configure
         read -r configure
         if [[ "$configure" != [yY] ]]; then
-            print -P "  スキップしました。"
+            msg_step "スキップしました。"
             return 0
         fi
     fi
 
     # Prompt for token value (silent input)
-    print -P -n "  トークンを入力してください: "
+    printf '  トークンを入力してください: '
     local token
     read -r -s token
-    print ""  # Newline after silent input
+    printf '\n'  # Newline after silent input
 
     if [[ -z "$token" ]]; then
-        print -P "  %F{220}警告: トークンが空です。スキップします。%f"
+        msg_step "$(printf '%s%s%s' "${C_YELLOW}" "警告: トークンが空です。スキップします。" "${C_RESET}")"
         return 0
     fi
 
     # Validate token characters (allow only safe characters to prevent injection)
     if [[ ! "$token" =~ ^[A-Za-z0-9_+/=.-]+$ ]]; then
-        print -P "%F{196}エラー: トークンに不正な文字が含まれています。%f"
+        msg_error "トークンに不正な文字が含まれています。"
         return 1
     fi
 
     # Warn if token seems too short
     if (( ${#token} < 10 )); then
-        print -P "%F{220}警告: トークンが短すぎます。正しい値か確認してください。%f"
+        msg_warn "トークンが短すぎます。正しい値か確認してください。"
     fi
 
     # Create directory with restricted permissions
     if [[ ! -d "$OP_MOD_TOKEN_DIR" ]]; then
         if (( DRY_RUN )); then
-            print -P "%F{242}  [DRY-RUN] mkdir -p ${OP_MOD_TOKEN_DIR} && chmod 700 ${OP_MOD_TOKEN_DIR}%f"
+            msg_dry_run "mkdir -p ${OP_MOD_TOKEN_DIR} && chmod 700 ${OP_MOD_TOKEN_DIR}"
         else
             mkdir -p "$OP_MOD_TOKEN_DIR" || {
-                print -P "%F{160}エラー: ${OP_MOD_TOKEN_DIR} の作成に失敗しました。%f" >&2
+                msg_error "${OP_MOD_TOKEN_DIR} の作成に失敗しました。"
                 return 1
             }
             chmod 700 "$OP_MOD_TOKEN_DIR" || {
-                print -P "%F{160}エラー: ${OP_MOD_TOKEN_DIR} のパーミッション設定に失敗しました。%f" >&2
+                msg_error "${OP_MOD_TOKEN_DIR} のパーミッション設定に失敗しました。"
                 return 1
             }
         fi
@@ -332,7 +332,7 @@ _1password_setup_service_account_token() {
 
     # Write token file with restricted permissions
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] トークンを ${OP_MOD_TOKEN_FILE} に保存 (chmod 600)%f"
+        msg_dry_run "トークンを ${OP_MOD_TOKEN_FILE} に保存 (chmod 600)"
     else
         # Write the token file atomically via a temp file
         # Set restrictive umask so mktemp creates files with safe permissions
@@ -342,27 +342,27 @@ _1password_setup_service_account_token() {
 
         local tmp_file
         tmp_file=$(mktemp "${OP_MOD_TOKEN_DIR}/.token.XXXXXX") || {
-            print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+            msg_error "一時ファイルの作成に失敗しました。"
             umask "$old_umask"
             return 1
         }
 
         chmod 600 "$tmp_file" || {
-            print -P "%F{160}エラー: 一時ファイルのパーミッション設定に失敗しました。%f" >&2
+            msg_error "一時ファイルのパーミッション設定に失敗しました。"
             rm -f "$tmp_file"
             umask "$old_umask"
             return 1
         }
 
         printf "export OP_SERVICE_ACCOUNT_TOKEN='%s'\n" "$token" > "$tmp_file" || {
-            print -P "%F{160}エラー: トークンの書き込みに失敗しました。%f" >&2
+            msg_error "トークンの書き込みに失敗しました。"
             rm -f "$tmp_file"
             umask "$old_umask"
             return 1
         }
 
         mv "$tmp_file" "$OP_MOD_TOKEN_FILE" || {
-            print -P "%F{160}エラー: トークンファイルの配置に失敗しました。%f" >&2
+            msg_error "トークンファイルの配置に失敗しました。"
             rm -f "$tmp_file"
             umask "$old_umask"
             return 1
@@ -370,46 +370,45 @@ _1password_setup_service_account_token() {
 
         umask "$old_umask"
 
-        print -P "  %F{34}トークンを保存しました: ${OP_MOD_TOKEN_FILE}%f"
+        msg_step "$(printf '%s%s%s' "${C_GREEN}" "トークンを保存しました: ${OP_MOD_TOKEN_FILE}" "${C_RESET}")"
     fi
 }
 
 # --- セットアップ ---
 setup_1password() {
-    print -P ""
-    print -P "%F{36}%B[1Password]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "1Password"
+    print_separator
 
     local env
     env=$(_1password_detect_env)
 
     case "$env" in
-        wsl)    print -P "情報: 環境を検出しました — WSL" ;;
-        linux)  print -P "情報: 環境を検出しました — ネイティブ Linux" ;;
-        macos)  print -P "情報: 環境を検出しました — macOS" ;;
+        wsl)    msg_info "環境を検出しました — WSL" ;;
+        linux)  msg_info "環境を検出しました — ネイティブ Linux" ;;
+        macos)  msg_info "環境を検出しました — macOS" ;;
         *)
-            print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+            msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
             return 1
             ;;
     esac
 
     # --- 1. op CLI のインストール ---
     if command -v op >/dev/null 2>&1; then
-        print -P "情報: op CLI は既にインストールされています ($(op --version 2>/dev/null || echo '不明'))。スキップします。"
+        msg_info "op CLI は既にインストールされています ($(op --version 2>/dev/null || echo '不明'))。スキップします。"
     else
-        print -P "1Password CLI (op) をインストールします..."
+        msg_info "1Password CLI (op) をインストールします..."
         case "$env" in
             wsl|linux)
                 if ! command -v apt-get >/dev/null 2>&1; then
-                    print -P "%F{160}エラー: apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。%f" >&2
+                    msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
                     return 1
                 fi
                 _1password_install_op_apt || return 1
                 ;;
             macos)
                 if ! command -v brew >/dev/null 2>&1; then
-                    print -P "%F{160}エラー: Homebrew がインストールされていません。%f" >&2
-                    print -P "  インストール: https://brew.sh/" >&2
+                    msg_error "Homebrew がインストールされていません。"
+                    msg_step "インストール: https://brew.sh/" >&2
                     return 1
                 fi
                 _1password_install_op_brew || return 1
@@ -418,22 +417,19 @@ setup_1password() {
 
         if (( ! DRY_RUN )); then
             if command -v op >/dev/null 2>&1; then
-                print -P "  %F{34}op CLI のインストールが完了しました ($(op --version 2>/dev/null))。%f"
+                msg_step "$(printf '%s%s%s' "${C_GREEN}" "op CLI のインストールが完了しました ($(op --version 2>/dev/null))。" "${C_RESET}")"
             else
-                print -P "%F{160}エラー: op CLI のインストール後にコマンドが見つかりません。%f" >&2
+                msg_error "op CLI のインストール後にコマンドが見つかりません。"
                 return 1
             fi
         fi
     fi
 
     # --- 2. 設定ファイルの配置 ---
-    print -P ""
-    print -P "設定ファイルを配置します..."
+    printf '\n'
+    msg_info "設定ファイルを配置します..."
     for entry in "${OP_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
@@ -447,16 +443,16 @@ setup_1password() {
     _1password_setup_service_account_token
 
     # --- 完了メッセージ ---
-    print -P ""
+    printf '\n'
     if (( DRY_RUN )); then
-        print -P "情報: 1Password セットアップ予定です（dry-run）。"
+        msg_info "1Password セットアップ予定です（dry-run）。"
     else
-        print -P "%F{34}1Password のセットアップが完了しました。%f"
+        msg_success "1Password のセットアップが完了しました。"
     fi
 
-    print -P ""
-    print -P "NOTE: 1Password デスクトップアプリが必要です。CLI 単体では認証できません。"
-    print -P "  初回は 'op signin' でサインインしてください。"
+    printf '\n'
+    printf '%s\n' "NOTE: 1Password デスクトップアプリが必要です。CLI 単体では認証できません。"
+    msg_step "初回は 'op signin' でサインインしてください。"
 }
 
 # --- アンインストール ---
@@ -469,19 +465,19 @@ uninstall_1password() {
         current_format=$(git config --global gpg.format 2>/dev/null || true)
         if [[ "$current_format" == "ssh" ]]; then
             if (( DRY_RUN )); then
-                print -P "%F{242}  [DRY-RUN] git config --global --unset gpg.format%f"
-                print -P "%F{242}  [DRY-RUN] git config --global --unset gpg.ssh.program%f"
-                print -P "%F{242}  [DRY-RUN] git config --global --unset commit.gpgsign%f"
+                msg_dry_run "git config --global --unset gpg.format"
+                msg_dry_run "git config --global --unset gpg.ssh.program"
+                msg_dry_run "git config --global --unset commit.gpgsign"
             else
                 git config --global --unset gpg.format 2>/dev/null
                 git config --global --unset gpg.ssh.program 2>/dev/null
                 git config --global --unset commit.gpgsign 2>/dev/null
-                print -P "情報: Git 署名設定を解除しました。"
+                msg_info "Git 署名設定を解除しました。"
                 local remaining_key
                 remaining_key=$(git config --global user.signingkey 2>/dev/null || true)
                 if [[ -n "$remaining_key" ]]; then
-                    print -P "  NOTE: user.signingkey ('${remaining_key}') は残っています。"
-                    print -P "  不要な場合は: git config --global --unset user.signingkey"
+                    msg_step "NOTE: user.signingkey ('${remaining_key}') は残っています。"
+                    msg_step "不要な場合は: git config --global --unset user.signingkey"
                 fi
             fi
             restored=1
@@ -490,82 +486,81 @@ uninstall_1password() {
 
     # サービスアカウントトークンの削除
     if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
-        print -P -n "サービスアカウントトークンを削除しますか？ (${OP_MOD_TOKEN_FILE}) [y/N]: "
+        printf 'サービスアカウントトークンを削除しますか？ (%s) [y/N]: ' "$OP_MOD_TOKEN_FILE"
         local remove_token
         read -r remove_token
         if [[ "$remove_token" == [yY] ]]; then
             if (( DRY_RUN )); then
-                print -P "%F{242}  [DRY-RUN] rm -f ${OP_MOD_TOKEN_FILE}%f"
+                msg_dry_run "rm -f ${OP_MOD_TOKEN_FILE}"
             else
                 # Use shred for secure deletion if available
                 if command -v shred >/dev/null 2>&1; then
                     shred -u "$OP_MOD_TOKEN_FILE" || {
-                        print -P "%F{160}エラー: トークンファイルの安全な削除に失敗しました。%f" >&2
+                        msg_error "トークンファイルの安全な削除に失敗しました。"
                         return 1
                     }
                 else
                     rm -f "$OP_MOD_TOKEN_FILE" || {
-                        print -P "%F{160}エラー: トークンファイルの削除に失敗しました。%f" >&2
+                        msg_error "トークンファイルの削除に失敗しました。"
                         return 1
                     }
                 fi
-                print -P "情報: サービスアカウントトークンを削除しました。"
+                msg_info "サービスアカウントトークンを削除しました。"
             fi
             restored=1
         else
-            print -P "情報: トークンファイルは残しました。手動で削除する場合: rm ${OP_MOD_TOKEN_FILE}"
+            msg_info "トークンファイルは残しました。手動で削除する場合: rm ${OP_MOD_TOKEN_FILE}"
         fi
     fi
 
     # 管理対象ファイルのバックアップ復元 / 削除
     for entry in "${OP_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "削除: ${label} を削除します。"
+            printf '%s\n' "削除: ${label} を削除します。"
             run_cmd command rm -f "$dst" || {
-                print -P "%F{160}エラー: ${label} の削除に失敗しました。%f" >&2
+                msg_error "${label} の削除に失敗しました。"
                 return 1
             }
             restored=1
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}1Password のアンインストールが完了しました。%f"
+        msg_success "1Password のアンインストールが完了しました。"
     else
-        print -P "情報: 1Password の復元・削除対象はありませんでした。"
+        msg_info "1Password の復元・削除対象はありませんでした。"
     fi
 
-    print -P ""
-    print -P "NOTE: 1Password CLI 本体は削除されていません。不要な場合は手動で削除してください:"
+    printf '\n'
+    printf '%s\n' "NOTE: 1Password CLI 本体は削除されていません。不要な場合は手動で削除してください:"
 
     local env
     env=$(_1password_detect_env)
     case "$env" in
         wsl|linux)
-            print -P "  sudo apt-get remove 1password-cli"
-            print -P "  sudo rm -f /etc/apt/sources.list.d/1password.list"
-            print -P "  sudo rm -f /etc/apt/keyrings/1password-archive-keyring.gpg"
+            msg_step "sudo apt-get remove 1password-cli"
+            msg_step "sudo rm -f /etc/apt/sources.list.d/1password.list"
+            msg_step "sudo rm -f /etc/apt/keyrings/1password-archive-keyring.gpg"
             ;;
         macos)
-            print -P "  brew uninstall --cask 1password-cli"
+            msg_step "brew uninstall --cask 1password-cli"
             ;;
         *)
-            print -P "  OS に応じたパッケージマネージャーで削除してください。"
+            msg_step "OS に応じたパッケージマネージャーで削除してください。"
             ;;
     esac
 }

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -375,7 +375,7 @@ _1password_setup_service_account_token() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_1password() {
     print -P ""
     print -P "%F{36}%B[1Password]%b%f"
     print -P "---------------------------------------------"
@@ -460,7 +460,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_1password() {
     local restored=0
 
     # Git 署名設定の解除

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -75,57 +75,57 @@ _claude_mod_merge_mcp_servers() {
 
     # テンプレートファイルの存在確認
     if [[ ! -f "$template" ]]; then
-        print -P "%F{220}警告: MCP サーバーテンプレートが見つかりません: ${template}%f"
-        print -P "  MCP サーバー設定のマージをスキップします。"
+        msg_warn "MCP サーバーテンプレートが見つかりません: ${template}"
+        msg_step "MCP サーバー設定のマージをスキップします。"
         return 0
     fi
 
     # jq の存在確認
     if ! command -v jq >/dev/null 2>&1; then
-        print -P "%F{220}警告: jq がインストールされていないため、MCP サーバー設定のマージをスキップします。%f"
-        print -P "  手動で設定するか、jq をインストールして再実行してください:"
-        print -P "    sudo apt install jq  # Debian/Ubuntu"
-        print -P "    brew install jq      # macOS"
+        msg_warn "jq がインストールされていないため、MCP サーバー設定のマージをスキップします。"
+        msg_step "手動で設定するか、jq をインストールして再実行してください:"
+        msg_step "  sudo apt install jq  # Debian/Ubuntu"
+        msg_step "  brew install jq      # macOS"
         return 0
     fi
 
     # テンプレートの JSON バリデーション
     if ! jq empty "$template" 2>/dev/null; then
-        print -P "%F{160}エラー: MCP サーバーテンプレートの JSON が不正です: ${template}%f" >&2
+        msg_error "MCP サーバーテンプレートの JSON が不正です: ${template}"
         return 1
     fi
 
     # ターゲットファイルが存在しない場合: テンプレートの内容でそのまま作成
     if [[ ! -f "$target" ]]; then
         if (( DRY_RUN )); then
-            print -P "情報: ${target} を新規作成予定です（dry-run）。"
+            msg_info "${target} を新規作成予定です（dry-run）。"
         else
             # NOTE: jq でフォーマットしてから書き出す（一時ファイル経由でアトミックに書き込む）
             local tmpfile
             tmpfile=$(mktemp "${target}.tmp.XXXXXX") || {
-                print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+                msg_error "一時ファイルの作成に失敗しました。"
                 return 1
             }
             jq '.' "$template" > "$tmpfile" || {
                 command rm -f "$tmpfile"
-                print -P "%F{160}エラー: ${target} の作成に失敗しました。%f" >&2
+                msg_error "${target} の作成に失敗しました。"
                 return 1
             }
             command mv "$tmpfile" "$target" || {
                 command rm -f "$tmpfile"
-                print -P "%F{160}エラー: ${target} への移動に失敗しました。%f" >&2
+                msg_error "${target} への移動に失敗しました。"
                 return 1
             }
             # NOTE: このモジュールで新規作成したことを記録するマーカーファイル
             touch "${target}.created-by-claude-mod"
-            print -P "情報: ${target} を新規作成しました（MCP サーバー設定）。"
+            msg_info "${target} を新規作成しました（MCP サーバー設定）。"
         fi
         return 0
     fi
 
     # 既存ファイルの JSON バリデーション
     if ! jq empty "$target" 2>/dev/null; then
-        print -P "%F{160}エラー: ${target} の JSON が不正です。手動で修正してください。%f" >&2
+        msg_error "${target} の JSON が不正です。手動で修正してください。"
         return 1
     fi
 
@@ -144,26 +144,26 @@ _claude_mod_merge_mcp_servers() {
             )
         ] | length > 0
     ' "$target" 2>/dev/null) || {
-        print -P "%F{160}エラー: MCP サーバー設定の比較に失敗しました。%f" >&2
+        msg_error "MCP サーバー設定の比較に失敗しました。"
         return 1
     }
 
     if [[ "$needs_update" == "false" ]]; then
-        print -P "情報: MCP サーバー設定は既に最新の状態です。スキップします。"
+        msg_info "MCP サーバー設定は既に最新の状態です。スキップします。"
         return 0
     fi
 
     # バックアップを作成してからマージ
     run_cmd command cp -p "$target" "${target}${BACKUP_SUFFIX}" || {
-        print -P "%F{160}エラー: ${target} のバックアップに失敗しました。%f" >&2
+        msg_error "${target} のバックアップに失敗しました。"
         return 1
     }
     if (( DRY_RUN )); then
-        print -P "情報: ${target} を ${target}${BACKUP_SUFFIX} にバックアップ予定です（dry-run）。"
-        print -P "情報: MCP サーバー設定をマージ予定です（dry-run）。"
+        msg_info "${target} を ${target}${BACKUP_SUFFIX} にバックアップ予定です（dry-run）。"
+        msg_info "MCP サーバー設定をマージ予定です（dry-run）。"
         return 0
     fi
-    print -P "情報: ${target} を ${target}${BACKUP_SUFFIX} にバックアップしました。"
+    msg_info "${target} を ${target}${BACKUP_SUFFIX} にバックアップしました。"
 
     # jq の再帰マージ (*) で mcpServers をマージ
     # NOTE: * 演算子はオブジェクトを再帰的にマージし、右辺（テンプレート）で上書きする
@@ -171,31 +171,31 @@ _claude_mod_merge_mcp_servers() {
     merged=$(jq --slurpfile tmpl "$template" '
         .mcpServers = ((.mcpServers // {}) * ($tmpl[0].mcpServers // {}))
     ' "$target" 2>/dev/null) || {
-        print -P "%F{160}エラー: MCP サーバー設定のマージに失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "MCP サーバー設定のマージに失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
 
     # マージ結果を書き出し（一時ファイル経由でアトミックに書き込む）
     local tmpfile
     tmpfile=$(mktemp "${target}.tmp.XXXXXX") || {
-        print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+        msg_error "一時ファイルの作成に失敗しました。"
         return 1
     }
     printf '%s\n' "$merged" > "$tmpfile" || {
         command rm -f "$tmpfile"
-        print -P "%F{160}エラー: ${target} への書き込みに失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "${target} への書き込みに失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
     command mv "$tmpfile" "$target" || {
         command rm -f "$tmpfile"
-        print -P "%F{160}エラー: ${target} への移動に失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "${target} への移動に失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
 
-    print -P "情報: MCP サーバー設定をマージしました。"
+    msg_info "MCP サーバー設定をマージしました。"
 }
 
 # --- MCP サーバー設定の削除 ---
@@ -207,25 +207,25 @@ _claude_mod_remove_mcp_servers() {
 
     # ターゲットファイルが存在しない場合はスキップ
     if [[ ! -f "$target" ]]; then
-        print -P "情報: ${target} が存在しません。MCP サーバー設定の削除をスキップします。"
+        msg_info "${target} が存在しません。MCP サーバー設定の削除をスキップします。"
         return 0
     fi
 
     # jq の存在確認
     if ! command -v jq >/dev/null 2>&1; then
-        print -P "%F{220}警告: jq がインストールされていないため、MCP サーバー設定の削除をスキップします。%f"
+        msg_warn "jq がインストールされていないため、MCP サーバー設定の削除をスキップします。"
         return 0
     fi
 
     # テンプレートが存在しない場合はスキップ
     if [[ ! -f "$template" ]]; then
-        print -P "%F{220}警告: MCP サーバーテンプレートが見つかりません。MCP サーバー設定の削除をスキップします。%f"
+        msg_warn "MCP サーバーテンプレートが見つかりません。MCP サーバー設定の削除をスキップします。"
         return 0
     fi
 
     # 既存ファイルの JSON バリデーション
     if ! jq empty "$target" 2>/dev/null; then
-        print -P "%F{220}警告: ${target} の JSON が不正です。MCP サーバー設定の削除をスキップします。%f"
+        msg_warn "${target} の JSON が不正です。MCP サーバー設定の削除をスキップします。"
         return 0
     fi
 
@@ -233,7 +233,7 @@ _claude_mod_remove_mcp_servers() {
     local has_mcp_servers
     has_mcp_servers=$(jq 'has("mcpServers")' "$target" 2>/dev/null)
     if [[ "$has_mcp_servers" != "true" ]]; then
-        print -P "情報: ${target} に mcpServers が存在しません。スキップします。"
+        msg_info "${target} に mcpServers が存在しません。スキップします。"
         return 0
     fi
 
@@ -243,7 +243,7 @@ _claude_mod_remove_mcp_servers() {
         server_names+=("$name")
     done < <(jq -r '.mcpServers | keys[]' "$template" 2>/dev/null)
     if (( ${#server_names[@]} == 0 )); then
-        print -P "情報: 削除対象の MCP サーバーがありません。スキップします。"
+        msg_info "削除対象の MCP サーバーがありません。スキップします。"
         return 0
     fi
 
@@ -259,21 +259,21 @@ _claude_mod_remove_mcp_servers() {
     done
 
     if (( ! has_any )); then
-        print -P "情報: 削除対象の MCP サーバーは存在しません。スキップします。"
+        msg_info "削除対象の MCP サーバーは存在しません。スキップします。"
         return 0
     fi
 
     # バックアップ
     run_cmd command cp -p "$target" "${target}${BACKUP_SUFFIX}" || {
-        print -P "%F{160}エラー: ${target} のバックアップに失敗しました。%f" >&2
+        msg_error "${target} のバックアップに失敗しました。"
         return 1
     }
     if (( DRY_RUN )); then
-        print -P "情報: ${target} を ${target}${BACKUP_SUFFIX} にバックアップ予定です（dry-run）。"
-        print -P "情報: MCP サーバー設定を削除予定です（dry-run）: ${server_names[*]}"
+        msg_info "${target} を ${target}${BACKUP_SUFFIX} にバックアップ予定です（dry-run）。"
+        msg_info "MCP サーバー設定を削除予定です（dry-run）: ${server_names[*]}"
         return 0
     fi
-    print -P "情報: ${target} を ${target}${BACKUP_SUFFIX} にバックアップしました。"
+    msg_info "${target} を ${target}${BACKUP_SUFFIX} にバックアップしました。"
 
     # jq でテンプレートに定義されたサーバーを一括削除
     # NOTE: jq の del() でキーを削除。サーバー名リストを JSON 配列として渡す
@@ -284,31 +284,31 @@ _claude_mod_remove_mcp_servers() {
     result=$(jq --argjson names "$names_json" '
         .mcpServers |= (. // {} | to_entries | map(select(.key as $k | $names | index($k) | not)) | from_entries)
     ' "$target" 2>/dev/null) || {
-        print -P "%F{160}エラー: MCP サーバー設定の削除に失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "MCP サーバー設定の削除に失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
 
     # 結果を書き出し（一時ファイル経由でアトミックに書き込む）
     local tmpfile
     tmpfile=$(mktemp "${target}.tmp.XXXXXX") || {
-        print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+        msg_error "一時ファイルの作成に失敗しました。"
         return 1
     }
     printf '%s\n' "$result" > "$tmpfile" || {
         command rm -f "$tmpfile"
-        print -P "%F{160}エラー: ${target} への書き込みに失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "${target} への書き込みに失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
     command mv "$tmpfile" "$target" || {
         command rm -f "$tmpfile"
-        print -P "%F{160}エラー: ${target} への移動に失敗しました。%f" >&2
-        print -P "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
+        msg_error "${target} への移動に失敗しました。"
+        printf '%s\n' "  バックアップから復元するには: mv '${target}${BACKUP_SUFFIX}' '${target}'" >&2
         return 1
     }
 
-    print -P "情報: MCP サーバー設定を削除しました: ${server_names[*]}"
+    msg_info "MCP サーバー設定を削除しました: ${server_names[*]}"
 
     # このモジュールで作成したファイルで、mcpServers 以外のキーがなく mcpServers が空の場合のみ削除
     if [[ -f "${target}.created-by-claude-mod" ]]; then
@@ -318,20 +318,19 @@ _claude_mod_remove_mcp_servers() {
         # mcpServers のみ（キー数1）かつ中身が空の場合のみファイル削除
         if [[ "$total_keys" == "1" ]] && [[ "$remaining_servers" == "0" ]]; then
             command rm -f "$target" "${target}.created-by-claude-mod"
-            print -P "情報: ${target} はこのモジュールで作成されたため削除しました。"
+            msg_info "${target} はこのモジュールで作成されたため削除しました。"
         elif [[ "$remaining_servers" == "0" ]]; then
             # mcpServers は空だが他のキーが存在する場合はマーカーのみ削除
             command rm -f "${target}.created-by-claude-mod"
-            print -P "情報: ${target} の mcpServers は空ですが、他の設定が存在するためファイルは保持します。"
+            msg_info "${target} の mcpServers は空ですが、他の設定が存在するためファイルは保持します。"
         fi
     fi
 }
 
 # --- セットアップ ---
 setup_claude_code() {
-    print -P ""
-    print -P "%F{36}%B[Claude Code]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Claude Code"
+    print_separator
 
     # =========================================
     # CLI インストール
@@ -340,69 +339,66 @@ setup_claude_code() {
     # べき等性チェック
     if command -v claude >/dev/null 2>&1; then
         local current_ver
-        current_ver=$(claude --version 2>/dev/null || print "unknown")
-        print -P "情報: Claude Code は既にインストールされています (${current_ver})。スキップします。"
+        current_ver=$(claude --version 2>/dev/null || printf '%s' "unknown")
+        msg_info "Claude Code は既にインストールされています (${current_ver})。スキップします。"
     else
         # Node.js / npm の確認
         if ! ensure_node; then
-            print -P "%F{220}スキップ: Claude Code のインストールには Node.js v18+ が必要です。%f"
+            msg_warn "Claude Code のインストールには Node.js v18+ が必要です。"
             return 1
         fi
 
-        print -P "Claude Code をインストールします..."
+        msg_info "Claude Code をインストールします..."
         run_cmd npm install -g @anthropic-ai/claude-code || {
-            print -P "%F{160}エラー: Claude Code のインストールに失敗しました。%f" >&2
-            print -P "  npm install -g の権限エラーの場合:" >&2
-            print -P "    npm config set prefix ~/.local" >&2
-            print -P "  または nvm/fnm をお使いの場合は sudo 不要です。" >&2
+            msg_error "Claude Code のインストールに失敗しました。"
+            msg_step "npm install -g の権限エラーの場合:" >&2
+            msg_step "  npm config set prefix ~/.local" >&2
+            msg_step "または nvm/fnm をお使いの場合は sudo 不要です。" >&2
             return 1
         }
 
         if (( DRY_RUN )); then
-            print -P "情報: Claude Code をインストール予定です（dry-run）。"
+            msg_info "Claude Code をインストール予定です（dry-run）。"
         else
-            print -P "%F{34}Claude Code のインストールが完了しました。%f"
-            print -P ""
-            print -P "初回セットアップ:"
-            print -P "  claude  # 対話的に API キーを設定"
-            print -P "  詳細: https://docs.anthropic.com/en/docs/claude-code"
+            msg_success "Claude Code のインストールが完了しました。"
+            printf '\n'
+            printf '%s\n' "初回セットアップ:"
+            msg_step "claude  # 対話的に API キーを設定"
+            msg_step "詳細: https://docs.anthropic.com/en/docs/claude-code"
         fi
     fi
 
     # =========================================
     # 設定ファイルの配置
     # =========================================
-    print -P ""
-    print -P "設定ファイルを配置します..."
+    printf '\n'
+    msg_info "設定ファイルを配置します..."
 
     # 必要なディレクトリを事前作成
     for dir in "${CLAUDE_MOD_REQUIRED_DIRS[@]}"; do
         if [[ ! -d "$dir" ]]; then
             run_cmd command mkdir -p "$dir" || {
-                print -P "%F{160}エラー: ${dir} の作成に失敗しました。%f" >&2
+                msg_error "${dir} の作成に失敗しました。"
                 return 1
             }
             if (( DRY_RUN )); then
-                print -P "情報: ${dir} を作成予定です（dry-run）。"
+                msg_info "${dir} を作成予定です（dry-run）。"
             else
-                print -P "情報: ${dir} を作成しました。"
+                msg_info "${dir} を作成しました。"
             fi
         fi
     done
 
     # 設定ファイルの配置
     for entry in "${CLAUDE_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
     # MCP サーバー設定のマージ（~/.claude.json に追加）
     _claude_mod_merge_mcp_servers || return 1
 
-    print -P "%F{34}Claude Code 設定ファイルの配置が完了しました。%f"
+    msg_success "Claude Code 設定ファイルの配置が完了しました。"
 }
 
 # --- アンインストール ---
@@ -418,31 +414,30 @@ uninstall_claude_code() {
     # 設定ファイルの復元・削除
     # =========================================
     for entry in "${CLAUDE_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        # Zsh Glob 限定子で最新のバックアップを検索（Om: 更新日時の降順、[1]: 最初の1件）
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        # find_newest_backup で最新のバックアップを検索
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "%F{220}警告: ${label} のバックアップが見つかりません。手動で確認してください: ${dst}%f"
+            msg_warn "${label} のバックアップが見つかりません。手動で確認してください: ${dst}"
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Claude Code 設定ファイルのアンインストールが完了しました。%f"
+        msg_success "Claude Code 設定ファイルのアンインストールが完了しました。"
     else
-        print -P "情報: Claude Code 設定ファイルの復元・削除対象はありませんでした。"
+        msg_info "Claude Code 設定ファイルの復元・削除対象はありませんでした。"
     fi
 
     # =========================================
@@ -451,23 +446,23 @@ uninstall_claude_code() {
 
     # インストール状態を判定（コマンドの存在 or npm パッケージの存在）
     if ! command -v claude >/dev/null 2>&1; then
-        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @anthropic-ai/claude-code >/dev/null 2>&1 }; then
-            print -P "情報: Claude Code はインストールされていません。スキップします。"
+        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @anthropic-ai/claude-code >/dev/null 2>&1; }; then
+            msg_info "Claude Code はインストールされていません。スキップします。"
             return 0
         fi
     fi
 
     if ! command -v npm >/dev/null 2>&1; then
-        print -P "%F{220}スキップ: npm が見つからないため Claude Code をアンインストールできません。%f"
+        msg_warn "npm が見つからないため Claude Code をアンインストールできません。"
         return 1
     fi
 
-    print -P "Claude Code をアンインストールします..."
+    msg_info "Claude Code をアンインストールします..."
     run_cmd npm uninstall -g @anthropic-ai/claude-code || {
-        print -P "%F{160}エラー: Claude Code のアンインストールに失敗しました。%f" >&2
+        msg_error "Claude Code のアンインストールに失敗しました。"
         return 1
     }
-    print -P "%F{34}Claude Code をアンインストールしました。%f"
-    print -P "NOTE: ~/.claude/ ディレクトリの空ディレクトリは削除されていません。不要な場合は手動で削除してください:"
-    print -P "  rm -rf ~/.claude/skills/"
+    msg_success "Claude Code をアンインストールしました。"
+    printf '%s\n' "NOTE: ~/.claude/ ディレクトリの空ディレクトリは削除されていません。不要な場合は手動で削除してください:"
+    msg_step "rm -rf ~/.claude/skills/"
 }

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -328,7 +328,7 @@ _claude_mod_remove_mcp_servers() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_claude_code() {
     print -P ""
     print -P "%F{36}%B[Claude Code]%b%f"
     print -P "---------------------------------------------"
@@ -406,7 +406,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_claude_code() {
     local restored=0
 
     # =========================================

--- a/dotfiles/modules/codex-cli.sh
+++ b/dotfiles/modules/codex-cli.sh
@@ -41,9 +41,8 @@ CODEX_MOD_REQUIRED_DIRS=(
 
 # --- セットアップ ---
 setup_codex_cli() {
-    print -P ""
-    print -P "%F{36}%B[Codex CLI]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Codex CLI"
+    print_separator
 
     # =========================================
     # CLI インストール
@@ -52,72 +51,69 @@ setup_codex_cli() {
     # べき等性チェック
     if command -v codex >/dev/null 2>&1; then
         local current_ver
-        current_ver=$(codex --version 2>/dev/null || print "unknown")
-        print -P "情報: Codex CLI は既にインストールされています (${current_ver})。スキップします。"
+        current_ver=$(codex --version 2>/dev/null || printf '%s' "unknown")
+        msg_info "Codex CLI は既にインストールされています (${current_ver})。スキップします。"
     else
         # Node.js / npm の確認
         if ! ensure_node; then
-            print -P "%F{220}スキップ: Codex CLI のインストールには Node.js v18+ が必要です。%f"
+            msg_warn "Codex CLI のインストールには Node.js v18+ が必要です。"
             return 1
         fi
 
-        print -P "Codex CLI をインストールします..."
+        msg_info "Codex CLI をインストールします..."
         run_cmd npm install -g @openai/codex || {
-            print -P "%F{160}エラー: Codex CLI のインストールに失敗しました。%f" >&2
-            print -P "  npm install -g の権限エラーの場合:" >&2
-            print -P "    npm config set prefix ~/.local" >&2
-            print -P "  または nvm/fnm をお使いの場合は sudo 不要です。" >&2
+            msg_error "Codex CLI のインストールに失敗しました。"
+            msg_step "npm install -g の権限エラーの場合:" >&2
+            msg_step "  npm config set prefix ~/.local" >&2
+            msg_step "または nvm/fnm をお使いの場合は sudo 不要です。" >&2
             return 1
         }
 
         if (( DRY_RUN )); then
-            print -P "情報: Codex CLI をインストール予定です（dry-run）。"
+            msg_info "Codex CLI をインストール予定です（dry-run）。"
         else
-            print -P "%F{34}Codex CLI のインストールが完了しました。%f"
-            print -P ""
-            print -P "初回セットアップ:"
-            print -P "  export OPENAI_API_KEY=<your-api-key>"
-            print -P "  codex  # 対話的に使用開始"
-            print -P "  詳細: https://github.com/openai/codex"
+            msg_success "Codex CLI のインストールが完了しました。"
+            printf '\n'
+            printf '%s\n' "初回セットアップ:"
+            msg_step "export OPENAI_API_KEY=<your-api-key>"
+            msg_step "codex  # 対話的に使用開始"
+            msg_step "詳細: https://github.com/openai/codex"
         fi
     fi
 
     # =========================================
     # 設定ファイルの配置
     # =========================================
-    print -P ""
-    print -P "設定ファイルを配置します..."
+    printf '\n'
+    msg_info "設定ファイルを配置します..."
 
     # 必要なディレクトリを事前作成（権限 700）
     for dir in "${CODEX_MOD_REQUIRED_DIRS[@]}"; do
         if [[ ! -d "$dir" ]]; then
             run_cmd command mkdir -p "$dir" || {
-                print -P "%F{160}エラー: ${dir} の作成に失敗しました。%f" >&2
+                msg_error "${dir} の作成に失敗しました。"
                 return 1
             }
             # NOTE: config may contain sensitive settings; restrict permissions
             run_cmd command chmod 700 "$dir" || {
-                print -P "%F{160}エラー: ${dir} の権限設定に失敗しました。%f" >&2
+                msg_error "${dir} の権限設定に失敗しました。"
                 return 1
             }
             if (( DRY_RUN )); then
-                print -P "情報: ${dir} を作成予定です（dry-run）。"
+                msg_info "${dir} を作成予定です（dry-run）。"
             else
-                print -P "情報: ${dir} を作成しました。"
+                msg_info "${dir} を作成しました。"
             fi
         fi
     done
 
     # 設定ファイルの配置
     for entry in "${CODEX_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
-    print -P "%F{34}Codex CLI 設定ファイルの配置が完了しました。%f"
+    msg_success "Codex CLI 設定ファイルの配置が完了しました。"
 }
 
 # --- アンインストール ---
@@ -128,31 +124,30 @@ uninstall_codex_cli() {
     # 設定ファイルの復元
     # =========================================
     for entry in "${CODEX_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        # Zsh Glob 限定子で最新のバックアップを検索（Om: 更新日時の降順、[1]: 最初の1件）
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        # find_newest_backup で最新のバックアップを検索
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "%F{220}警告: ${label} のバックアップが見つかりません。手動で確認してください: ${dst}%f"
+            msg_warn "${label} のバックアップが見つかりません。手動で確認してください: ${dst}"
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Codex CLI 設定ファイルのアンインストールが完了しました。%f"
+        msg_success "Codex CLI 設定ファイルのアンインストールが完了しました。"
     else
-        print -P "情報: Codex CLI 設定ファイルの復元・削除対象はありませんでした。"
+        msg_info "Codex CLI 設定ファイルの復元・削除対象はありませんでした。"
     fi
 
     # =========================================
@@ -161,24 +156,24 @@ uninstall_codex_cli() {
 
     # インストール状態を判定（コマンドの存在 or npm パッケージの存在）
     if ! command -v codex >/dev/null 2>&1; then
-        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @openai/codex >/dev/null 2>&1 }; then
-            print -P "情報: Codex CLI はインストールされていません。スキップします。"
+        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @openai/codex >/dev/null 2>&1; }; then
+            msg_info "Codex CLI はインストールされていません。スキップします。"
             return 0
         fi
     fi
 
     if ! command -v npm >/dev/null 2>&1; then
-        print -P "%F{220}スキップ: npm が見つからないため Codex CLI をアンインストールできません。%f"
+        msg_warn "npm が見つからないため Codex CLI をアンインストールできません。"
         return 1
     fi
 
-    print -P "Codex CLI をアンインストールします..."
+    msg_info "Codex CLI をアンインストールします..."
     run_cmd npm uninstall -g @openai/codex || {
-        print -P "%F{160}エラー: Codex CLI のアンインストールに失敗しました。%f" >&2
+        msg_error "Codex CLI のアンインストールに失敗しました。"
         return 1
     }
-    print -P "%F{34}Codex CLI をアンインストールしました。%f"
+    msg_success "Codex CLI をアンインストールしました。"
     # NOTE: ~/.codex/ ディレクトリはユーザーデータ（セッション、メモリ等）を含むため削除しない
-    print -P "NOTE: ~/.codex/ ディレクトリはユーザーデータを含むため削除されていません。不要な場合は手動で削除してください:"
-    print -P "  rm -rf ~/.codex/"
+    printf '%s\n' "NOTE: ~/.codex/ ディレクトリはユーザーデータを含むため削除されていません。不要な場合は手動で削除してください:"
+    msg_step "rm -rf ~/.codex/"
 }

--- a/dotfiles/modules/codex-cli.sh
+++ b/dotfiles/modules/codex-cli.sh
@@ -40,7 +40,7 @@ CODEX_MOD_REQUIRED_DIRS=(
 )
 
 # --- セットアップ ---
-module_setup() {
+setup_codex_cli() {
     print -P ""
     print -P "%F{36}%B[Codex CLI]%b%f"
     print -P "---------------------------------------------"
@@ -121,7 +121,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_codex_cli() {
     local restored=0
 
     # =========================================

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -200,7 +200,7 @@ _docker_setup_group() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_docker() {
     print -P ""
     print -P "%F{36}%B[Docker]%b%f"
     print -P "---------------------------------------------"
@@ -274,7 +274,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_docker() {
     local env
     env=$(_docker_detect_env)
 

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -26,9 +26,9 @@ DOCKER_MOD_APT_PACKAGES=(
 # 戻り値: "macos" / "linux" / "unknown"
 _docker_detect_env() {
     case "$OSTYPE" in
-        darwin*) print "macos" ;;
-        linux*)  print "linux" ;;
-        *)       print "unknown" ;;
+        darwin*) printf '%s' "macos" ;;
+        linux*)  printf '%s' "linux" ;;
+        *)       printf '%s' "unknown" ;;
     esac
 }
 
@@ -41,20 +41,20 @@ _docker_is_installed() {
 
     # Docker バイナリは存在する; Compose プラグインを確認
     if ! docker compose version >/dev/null 2>&1; then
-        print -P "%F{220}警告: Docker はインストールされていますが、Compose プラグインが見つかりません。再インストールします。%f"
+        msg_warn "Docker はインストールされていますが、Compose プラグインが見つかりません。再インストールします。"
         return 1
     fi
 
     local docker_ver compose_ver
-    docker_ver=$(docker --version 2>/dev/null || print "unknown")
-    compose_ver=$(docker compose version 2>/dev/null || print "unknown")
-    print -P "情報: Docker は既にインストールされています (${docker_ver}, ${compose_ver})。スキップします。"
+    docker_ver=$(docker --version 2>/dev/null || printf '%s' "unknown")
+    compose_ver=$(docker compose version 2>/dev/null || printf '%s' "unknown")
+    msg_info "Docker は既にインストールされています (${docker_ver}, ${compose_ver})。スキップします。"
     return 0
 }
 
 # --- ヘルパー: Docker Engine の apt インストール (Ubuntu/Debian) ---
 _docker_install_apt() {
-    print -P "  Docker Engine を apt でインストールします..."
+    msg_step "Docker Engine を apt でインストールします..."
 
     # ディストリビューションを検出 (ubuntu または debian)
     local distro
@@ -62,7 +62,7 @@ _docker_install_apt() {
     case "$distro" in
         ubuntu|debian) ;;
         *)
-            print -P "%F{160}エラー: 未対応のディストリビューションです (${distro})。Ubuntu または Debian が必要です。%f" >&2
+            msg_error "未対応のディストリビューションです (${distro})。Ubuntu または Debian が必要です。"
             return 1
             ;;
     esac
@@ -75,40 +75,40 @@ _docker_install_apt() {
             docker-doc podman-docker containerd runc \
             2>/dev/null | cut -f1))
         if (( ${#old_pkgs[@]} > 0 )); then
-            print -P "  競合する旧パッケージを削除します: ${old_pkgs[*]}"
+            msg_step "競合する旧パッケージを削除します: ${old_pkgs[*]}"
             run_cmd sudo apt-get remove -y "${old_pkgs[@]}" 2>/dev/null || true
         fi
     else
-        print -P "%F{242}  [DRY-RUN] sudo apt-get remove (conflicting packages)%f"
+        msg_dry_run "sudo apt-get remove (conflicting packages)"
     fi
 
     # ステップ 2: 前提パッケージのインストール
     run_cmd sudo apt-get update -qq || {
-        print -P "%F{220}警告: apt update に失敗しました。%f"
+        msg_warn "apt update に失敗しました。"
     }
     run_cmd sudo apt-get install -y ca-certificates curl || {
-        print -P "%F{160}エラー: 前提パッケージのインストールに失敗しました。%f" >&2
+        msg_error "前提パッケージのインストールに失敗しました。"
         return 1
     }
 
     # ステップ 3: Docker GPG キーの追加
     run_cmd sudo install -m 0755 -d /etc/apt/keyrings || {
-        print -P "%F{160}エラー: /etc/apt/keyrings の作成に失敗しました。%f" >&2
+        msg_error "/etc/apt/keyrings の作成に失敗しました。"
         return 1
     }
 
     if (( ! DRY_RUN )); then
         sudo curl -fsSL "https://download.docker.com/linux/${distro}/gpg" \
             -o "$DOCKER_MOD_GPG_KEY" || {
-            print -P "%F{160}エラー: Docker の GPG キー取得に失敗しました。%f" >&2
+            msg_error "Docker の GPG キー取得に失敗しました。"
             return 1
         }
         sudo chmod a+r "$DOCKER_MOD_GPG_KEY" || {
-            print -P "%F{160}エラー: GPG キーのパーミッション設定に失敗しました。%f" >&2
+            msg_error "GPG キーのパーミッション設定に失敗しました。"
             return 1
         }
     else
-        print -P "%F{242}  [DRY-RUN] curl -fsSL https://download.docker.com/linux/${distro}/gpg -o ${DOCKER_MOD_GPG_KEY}%f"
+        msg_dry_run "curl -fsSL https://download.docker.com/linux/${distro}/gpg -o ${DOCKER_MOD_GPG_KEY}"
     fi
 
     # ステップ 4: Docker APT リポジトリの追加 (DEB822 形式)
@@ -116,7 +116,7 @@ _docker_install_apt() {
         local codename
         codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
         if [[ -z "$codename" ]]; then
-            print -P "%F{160}エラー: Ubuntu/Debian のコードネームを検出できませんでした。%f" >&2
+            msg_error "Ubuntu/Debian のコードネームを検出できませんでした。"
             return 1
         fi
 
@@ -126,20 +126,20 @@ Suites: ${codename}
 Components: stable
 Signed-By: ${DOCKER_MOD_GPG_KEY}"
 
-        print "$sources_content" | sudo tee "$DOCKER_MOD_APT_SOURCE" >/dev/null || {
-            print -P "%F{160}エラー: Docker の apt ソース追加に失敗しました。%f" >&2
+        printf '%s\n' "$sources_content" | sudo tee "$DOCKER_MOD_APT_SOURCE" >/dev/null || {
+            msg_error "Docker の apt ソース追加に失敗しました。"
             return 1
         }
     else
-        print -P "%F{242}  [DRY-RUN] sudo tee ${DOCKER_MOD_APT_SOURCE} (DEB822 format)%f"
+        msg_dry_run "sudo tee ${DOCKER_MOD_APT_SOURCE} (DEB822 format)"
     fi
 
     # ステップ 5: Docker Engine + Compose プラグインのインストール
     run_cmd sudo apt-get update -qq || {
-        print -P "%F{220}警告: apt update に失敗しました。%f"
+        msg_warn "apt update に失敗しました。"
     }
     run_cmd sudo apt-get install -y "${DOCKER_MOD_APT_PACKAGES[@]}" || {
-        print -P "%F{160}エラー: Docker Engine のインストールに失敗しました。%f" >&2
+        msg_error "Docker Engine のインストールに失敗しました。"
         return 1
     }
 }
@@ -147,14 +147,14 @@ Signed-By: ${DOCKER_MOD_GPG_KEY}"
 # --- ヘルパー: Docker Desktop の Homebrew インストール (macOS) ---
 _docker_install_macos() {
     if ! command -v brew >/dev/null 2>&1; then
-        print -P "%F{160}エラー: Homebrew がインストールされていません。%f" >&2
-        print -P "  インストール: https://brew.sh/" >&2
+        msg_error "Homebrew がインストールされていません。"
+        msg_step "インストール: https://brew.sh/" >&2
         return 1
     fi
 
-    print -P "  Docker Desktop を Homebrew でインストールします..."
+    msg_step "Docker Desktop を Homebrew でインストールします..."
     run_cmd brew install --cask docker || {
-        print -P "%F{160}エラー: Docker Desktop のインストールに失敗しました。%f" >&2
+        msg_error "Docker Desktop のインストールに失敗しました。"
         return 1
     }
 }
@@ -164,55 +164,54 @@ _docker_setup_group() {
     # NOTE: sudo 実行時に $USER が "root" になるため、実際の呼び出しユーザーを解決
     local target_user="${SUDO_USER:-$(id -un)}"
 
-    print -P ""
-    print -P "Docker グループ設定:"
+    printf '\n'
+    printf '%s\n' "Docker グループ設定:"
 
     # docker グループの作成（べき等: -f により既存でもエラーにならない）
     run_cmd sudo groupadd -f docker || {
-        print -P "%F{160}エラー: docker グループの作成に失敗しました。%f" >&2
+        msg_error "docker グループの作成に失敗しました。"
         return 1
     }
 
     # 現在のユーザーを docker グループに追加
     if id -nG "$target_user" 2>/dev/null | grep -qw docker; then
-        print -P "  情報: ユーザー ${target_user} は既に docker グループに所属しています。"
+        msg_step "情報: ユーザー ${target_user} は既に docker グループに所属しています。"
     else
         run_cmd sudo usermod -aG docker "$target_user" || {
-            print -P "%F{160}エラー: ユーザーの docker グループ追加に失敗しました。%f" >&2
+            msg_error "ユーザーの docker グループ追加に失敗しました。"
             return 1
         }
-        print -P "  %F{220}NOTE: docker グループの変更を反映するには再ログインが必要です。%f"
+        msg_step "$(printf '%s%s%s' "${C_YELLOW}" "NOTE: docker グループの変更を反映するには再ログインが必要です。" "${C_RESET}")"
     fi
 
     # systemd による自動起動の有効化（利用可能な場合）
     if command -v systemctl >/dev/null 2>&1; then
-        print -P ""
-        print -P "systemd サービスの有効化:"
+        printf '\n'
+        printf '%s\n' "systemd サービスの有効化:"
         run_cmd sudo systemctl enable docker.service || {
-            print -P "%F{220}警告: docker.service の有効化に失敗しました。%f"
+            msg_warn "docker.service の有効化に失敗しました。"
         }
         run_cmd sudo systemctl enable containerd.service || {
-            print -P "%F{220}警告: containerd.service の有効化に失敗しました。%f"
+            msg_warn "containerd.service の有効化に失敗しました。"
         }
     else
-        print -P "  %F{220}NOTE: systemctl が見つかりません。Docker の自動起動は手動で設定してください。%f"
+        msg_step "$(printf '%s%s%s' "${C_YELLOW}" "NOTE: systemctl が見つかりません。Docker の自動起動は手動で設定してください。" "${C_RESET}")"
     fi
 }
 
 # --- セットアップ ---
 setup_docker() {
-    print -P ""
-    print -P "%F{36}%B[Docker]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Docker"
+    print_separator
 
     local env
     env=$(_docker_detect_env)
 
     case "$env" in
-        linux)  print -P "情報: 環境を検出しました — Linux" ;;
-        macos)  print -P "情報: 環境を検出しました — macOS" ;;
+        linux)  msg_info "環境を検出しました — Linux" ;;
+        macos)  msg_info "環境を検出しました — macOS" ;;
         *)
-            print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+            msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
             return 1
             ;;
     esac
@@ -222,11 +221,11 @@ setup_docker() {
         # インストール済み; インストールをスキップ
         :
     else
-        print -P "Docker をインストールします..."
+        msg_info "Docker をインストールします..."
         case "$env" in
             linux)
                 if ! command -v apt-get >/dev/null 2>&1; then
-                    print -P "%F{160}エラー: apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。%f" >&2
+                    msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
                     return 1
                 fi
                 _docker_install_apt || return 1
@@ -239,9 +238,9 @@ setup_docker() {
         # インストールの確認
         if (( ! DRY_RUN )); then
             if command -v docker >/dev/null 2>&1; then
-                print -P "  %F{34}Docker のインストールが完了しました ($(docker --version 2>/dev/null))。%f"
+                msg_step "$(printf '%s%s%s' "${C_GREEN}" "Docker のインストールが完了しました ($(docker --version 2>/dev/null))。" "${C_RESET}")"
             else
-                print -P "%F{160}エラー: Docker のインストール後にコマンドが見つかりません。%f" >&2
+                msg_error "Docker のインストール後にコマンドが見つかりません。"
                 return 1
             fi
         fi
@@ -253,23 +252,23 @@ setup_docker() {
     fi
 
     # --- 完了メッセージ ---
-    print -P ""
+    printf '\n'
     if (( DRY_RUN )); then
-        print -P "情報: Docker セットアップ予定です（dry-run）。"
+        msg_info "Docker セットアップ予定です（dry-run）。"
     else
-        print -P "%F{34}Docker のセットアップが完了しました。%f"
+        msg_success "Docker のセットアップが完了しました。"
         if command -v docker >/dev/null 2>&1; then
-            print -P "  Docker: $(docker --version 2>/dev/null || print 'N/A')"
+            msg_step "Docker: $(docker --version 2>/dev/null || printf '%s' 'N/A')"
             # Compose バージョンの表示（利用可能な場合）
             local compose_ver
             compose_ver=$(docker compose version 2>/dev/null || true)
-            [[ -n "$compose_ver" ]] && print -P "  Compose: ${compose_ver}"
+            [[ -n "$compose_ver" ]] && msg_step "Compose: ${compose_ver}"
         fi
     fi
 
     if [[ "$env" == "macos" ]]; then
-        print -P ""
-        print -P "NOTE: Docker Desktop を起動してセットアップを完了してください。"
+        printf '\n'
+        printf '%s\n' "NOTE: Docker Desktop を起動してセットアップを完了してください。"
     fi
 }
 
@@ -281,14 +280,14 @@ uninstall_docker() {
     case "$env" in
         linux)
             if ! command -v apt-get >/dev/null 2>&1; then
-                print -P "%F{160}エラー: apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。%f" >&2
+                msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
                 return 1
             fi
-            print -P "Docker Engine を削除します..."
+            msg_info "Docker Engine を削除します..."
 
             # Docker パッケージの削除
             run_cmd sudo apt-get purge -y "${DOCKER_MOD_APT_PACKAGES[@]}" docker-ce-rootless-extras 2>/dev/null || {
-                print -P "%F{220}警告: Docker パッケージの削除に失敗しました（既に削除済みの可能性があります）。%f"
+                msg_warn "Docker パッケージの削除に失敗しました（既に削除済みの可能性があります）。"
             }
 
             run_cmd sudo apt-get autoremove -y 2>/dev/null || true
@@ -296,38 +295,38 @@ uninstall_docker() {
             # APT ソースと GPG キーの削除
             if [[ -f "$DOCKER_MOD_APT_SOURCE" ]]; then
                 run_cmd sudo rm -f "$DOCKER_MOD_APT_SOURCE" || {
-                    print -P "%F{220}警告: ${DOCKER_MOD_APT_SOURCE} の削除に失敗しました。%f"
+                    msg_warn "${DOCKER_MOD_APT_SOURCE} の削除に失敗しました。"
                 }
             fi
 
             if [[ -f "$DOCKER_MOD_GPG_KEY" ]]; then
                 run_cmd sudo rm -f "$DOCKER_MOD_GPG_KEY" || {
-                    print -P "%F{220}警告: ${DOCKER_MOD_GPG_KEY} の削除に失敗しました。%f"
+                    msg_warn "${DOCKER_MOD_GPG_KEY} の削除に失敗しました。"
                 }
             fi
 
-            print -P "%F{34}Docker Engine のアンインストールが完了しました。%f"
-            print -P ""
-            print -P "NOTE: Docker のデータ（イメージ、コンテナ、ボリューム等）は残っています。"
-            print -P "  完全に削除する場合:"
-            print -P "    sudo rm -rf /var/lib/docker"
-            print -P "    sudo rm -rf /var/lib/containerd"
+            msg_success "Docker Engine のアンインストールが完了しました。"
+            printf '\n'
+            printf '%s\n' "NOTE: Docker のデータ（イメージ、コンテナ、ボリューム等）は残っています。"
+            msg_step "完全に削除する場合:"
+            msg_step "  sudo rm -rf /var/lib/docker"
+            msg_step "  sudo rm -rf /var/lib/containerd"
             ;;
         macos)
-            print -P "Docker Desktop を削除します..."
+            msg_info "Docker Desktop を削除します..."
             if ! command -v brew >/dev/null 2>&1; then
-                print -P "%F{160}エラー: Homebrew が見つかりません。手動で削除してください。%f" >&2
+                msg_error "Homebrew が見つかりません。手動で削除してください。"
                 return 1
             fi
 
             run_cmd brew uninstall --cask docker || {
-                print -P "%F{220}警告: Docker Desktop の削除に失敗しました（既に削除済みの可能性があります）。%f"
+                msg_warn "Docker Desktop の削除に失敗しました（既に削除済みの可能性があります）。"
             }
 
-            print -P "%F{34}Docker Desktop のアンインストールが完了しました。%f"
+            msg_success "Docker Desktop のアンインストールが完了しました。"
             ;;
         *)
-            print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+            msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
             return 1
             ;;
     esac

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -36,7 +36,7 @@ GEMINI_MOD_REQUIRED_DIRS=(
 )
 
 # --- セットアップ ---
-module_setup() {
+setup_gemini_cli() {
     print -P ""
     print -P "%F{36}%B[Gemini CLI]%b%f"
     print -P "---------------------------------------------"
@@ -116,7 +116,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_gemini_cli() {
     local restored=0
 
     # =========================================

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -37,9 +37,8 @@ GEMINI_MOD_REQUIRED_DIRS=(
 
 # --- セットアップ ---
 setup_gemini_cli() {
-    print -P ""
-    print -P "%F{36}%B[Gemini CLI]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Gemini CLI"
+    print_separator
 
     # =========================================
     # CLI インストール
@@ -48,71 +47,68 @@ setup_gemini_cli() {
     # べき等性チェック
     if command -v gemini >/dev/null 2>&1; then
         local current_ver
-        current_ver=$(gemini --version 2>/dev/null || print "unknown")
-        print -P "情報: Gemini CLI は既にインストールされています (${current_ver})。スキップします。"
+        current_ver=$(gemini --version 2>/dev/null || printf '%s' "unknown")
+        msg_info "Gemini CLI は既にインストールされています (${current_ver})。スキップします。"
     else
         # Node.js / npm の確認
         if ! ensure_node 20; then
-            print -P "%F{220}スキップ: Gemini CLI のインストールには Node.js v20+ が必要です。%f"
+            msg_warn "Gemini CLI のインストールには Node.js v20+ が必要です。"
             return 1
         fi
 
-        print -P "Gemini CLI をインストールします..."
+        msg_info "Gemini CLI をインストールします..."
         run_cmd npm install -g @google/gemini-cli || {
-            print -P "%F{160}エラー: Gemini CLI のインストールに失敗しました。%f" >&2
-            print -P "  npm install -g の権限エラーの場合:" >&2
-            print -P "    npm config set prefix ~/.local" >&2
-            print -P "  または nvm/fnm をお使いの場合は sudo 不要です。" >&2
+            msg_error "Gemini CLI のインストールに失敗しました。"
+            msg_step "npm install -g の権限エラーの場合:" >&2
+            msg_step "  npm config set prefix ~/.local" >&2
+            msg_step "または nvm/fnm をお使いの場合は sudo 不要です。" >&2
             return 1
         }
 
         if (( DRY_RUN )); then
-            print -P "情報: Gemini CLI をインストール予定です（dry-run）。"
+            msg_info "Gemini CLI をインストール予定です（dry-run）。"
         else
-            print -P "%F{34}Gemini CLI のインストールが完了しました。%f"
-            print -P ""
-            print -P "初回セットアップ:"
-            print -P "  gemini  # Google アカウントで認証"
-            print -P "  詳細: https://github.com/google-gemini/gemini-cli"
+            msg_success "Gemini CLI のインストールが完了しました。"
+            printf '\n'
+            printf '%s\n' "初回セットアップ:"
+            msg_step "gemini  # Google アカウントで認証"
+            msg_step "詳細: https://github.com/google-gemini/gemini-cli"
         fi
     fi
 
     # =========================================
     # 設定ファイルの配置
     # =========================================
-    print -P ""
-    print -P "設定ファイルを配置します..."
+    printf '\n'
+    msg_info "設定ファイルを配置します..."
 
     # 必要なディレクトリを事前作成（権限 700）
     for dir in "${GEMINI_MOD_REQUIRED_DIRS[@]}"; do
         if [[ ! -d "$dir" ]]; then
             run_cmd command mkdir -p "$dir" || {
-                print -P "%F{160}エラー: ${dir} の作成に失敗しました。%f" >&2
+                msg_error "${dir} の作成に失敗しました。"
                 return 1
             }
             # NOTE: config may contain sensitive settings; restrict permissions
             run_cmd command chmod 700 "$dir" || {
-                print -P "%F{160}エラー: ${dir} の権限設定に失敗しました。%f" >&2
+                msg_error "${dir} の権限設定に失敗しました。"
                 return 1
             }
             if (( DRY_RUN )); then
-                print -P "情報: ${dir} を作成予定です（dry-run）。"
+                msg_info "${dir} を作成予定です（dry-run）。"
             else
-                print -P "情報: ${dir} を作成しました。"
+                msg_info "${dir} を作成しました。"
             fi
         fi
     done
 
     # 設定ファイルの配置
     for entry in "${GEMINI_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
-    print -P "%F{34}Gemini CLI 設定ファイルの配置が完了しました。%f"
+    msg_success "Gemini CLI 設定ファイルの配置が完了しました。"
 }
 
 # --- アンインストール ---
@@ -123,31 +119,30 @@ uninstall_gemini_cli() {
     # 設定ファイルの復元
     # =========================================
     for entry in "${GEMINI_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        # Zsh Glob 限定子で最新のバックアップを検索（Om: 更新日時の降順、[1]: 最初の1件）
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        # find_newest_backup で最新のバックアップを検索
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "%F{220}警告: ${label} のバックアップが見つかりません。手動で確認してください: ${dst}%f"
+            msg_warn "${label} のバックアップが見つかりません。手動で確認してください: ${dst}"
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Gemini CLI 設定ファイルのアンインストールが完了しました。%f"
+        msg_success "Gemini CLI 設定ファイルのアンインストールが完了しました。"
     else
-        print -P "情報: Gemini CLI 設定ファイルの復元・削除対象はありませんでした。"
+        msg_info "Gemini CLI 設定ファイルの復元・削除対象はありませんでした。"
     fi
 
     # =========================================
@@ -156,24 +151,24 @@ uninstall_gemini_cli() {
 
     # インストール状態を判定（コマンドの存在 or npm パッケージの存在）
     if ! command -v gemini >/dev/null 2>&1; then
-        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @google/gemini-cli >/dev/null 2>&1 }; then
-            print -P "情報: Gemini CLI はインストールされていません。スキップします。"
+        if ! { command -v npm >/dev/null 2>&1 && npm ls -g @google/gemini-cli >/dev/null 2>&1; }; then
+            msg_info "Gemini CLI はインストールされていません。スキップします。"
             return 0
         fi
     fi
 
     if ! command -v npm >/dev/null 2>&1; then
-        print -P "%F{220}スキップ: npm が見つからないため Gemini CLI をアンインストールできません。%f"
+        msg_warn "npm が見つからないため Gemini CLI をアンインストールできません。"
         return 1
     fi
 
-    print -P "Gemini CLI をアンインストールします..."
+    msg_info "Gemini CLI をアンインストールします..."
     run_cmd npm uninstall -g @google/gemini-cli || {
-        print -P "%F{160}エラー: Gemini CLI のアンインストールに失敗しました。%f" >&2
+        msg_error "Gemini CLI のアンインストールに失敗しました。"
         return 1
     }
-    print -P "%F{34}Gemini CLI をアンインストールしました。%f"
+    msg_success "Gemini CLI をアンインストールしました。"
     # NOTE: ~/.gemini/ ディレクトリはユーザーデータ（セッション等）を含むため削除しない
-    print -P "NOTE: ~/.gemini/ ディレクトリはユーザーデータを含むため削除されていません。不要な場合は手動で削除してください:"
-    print -P "  rm -rf ~/.gemini/"
+    printf '%s\n' "NOTE: ~/.gemini/ ディレクトリはユーザーデータを含むため削除されていません。不要な場合は手動で削除してください:"
+    msg_step "rm -rf ~/.gemini/"
 }

--- a/dotfiles/modules/git.sh
+++ b/dotfiles/modules/git.sh
@@ -23,24 +23,20 @@ GIT_MOD_MANAGED_FILES=(
 
 # --- セットアップ ---
 setup_git() {
-    print -P ""
-    print -P "%F{36}%B[Git グローバル設定]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Git グローバル設定"
+    print_separator
 
     # git コマンドの存在確認
     if ! command -v git >/dev/null 2>&1; then
-        print -P "%F{160}エラー: git コマンドが見つかりません。インストールしてください。%f" >&2
+        msg_error "git コマンドが見つかりません。インストールしてください。"
         return 1
     fi
-    print -P "情報: git が利用可能です ($(command git --version))"
+    msg_info "git が利用可能です ($(command git --version))"
 
     # 設定ファイルの配置
-    print -P "設定ファイルを配置します..."
+    msg_info "設定ファイルを配置します..."
     for entry in "${GIT_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
@@ -51,9 +47,9 @@ setup_git() {
     _git_setup_excludes_file || return 1
 
     if (( DRY_RUN )); then
-        print -P "情報: Git グローバル設定をセットアップ予定です（dry-run）。"
+        msg_info "Git グローバル設定をセットアップ予定です（dry-run）。"
     else
-        print -P "%F{34}Git グローバル設定のセットアップが完了しました。%f"
+        msg_success "Git グローバル設定のセットアップが完了しました。"
     fi
 
     # user.name / user.email の設定ガイド
@@ -66,18 +62,18 @@ _git_setup_include_path() {
 
     # 既に設定済みか確認
     if git config --global --get-all include.path 2>/dev/null | grep -qF "$shared_path"; then
-        print -P "情報: include.path は既に設定されています。スキップします。"
+        msg_info "include.path は既に設定されています。スキップします。"
         return 0
     fi
 
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] git config --global --add include.path ${shared_path}%f"
+        msg_dry_run "git config --global --add include.path ${shared_path}"
     else
         git config --global --add include.path "$shared_path" || {
-            print -P "%F{160}エラー: include.path の設定に失敗しました。%f" >&2
+            msg_error "include.path の設定に失敗しました。"
             return 1
         }
-        print -P "情報: include.path に ${shared_path} を追加しました。"
+        msg_info "include.path に ${shared_path} を追加しました。"
     fi
 }
 
@@ -89,24 +85,24 @@ _git_setup_excludes_file() {
     local current_excludes
     current_excludes=$(git config --global core.excludesFile 2>/dev/null || true)
     if [[ "$current_excludes" == "$excludes_path" ]]; then
-        print -P "情報: core.excludesFile は既に設定されています。スキップします。"
+        msg_info "core.excludesFile は既に設定されています。スキップします。"
         return 0
     fi
 
     if (( DRY_RUN )); then
         if [[ -n "$current_excludes" && "$current_excludes" != "$excludes_path" ]]; then
-            print -P "%F{220}警告: core.excludesFile が ${current_excludes} から ${excludes_path} に変更されます。%f"
+            msg_warn "core.excludesFile が ${current_excludes} から ${excludes_path} に変更されます。"
         fi
-        print -P "%F{242}  [DRY-RUN] git config --global core.excludesFile ${excludes_path}%f"
+        msg_dry_run "git config --global core.excludesFile ${excludes_path}"
     else
         git config --global core.excludesFile "$excludes_path" || {
-            print -P "%F{160}エラー: core.excludesFile の設定に失敗しました。%f" >&2
+            msg_error "core.excludesFile の設定に失敗しました。"
             return 1
         }
         if [[ -n "$current_excludes" && "$current_excludes" != "$excludes_path" ]]; then
-            print -P "%F{220}警告: core.excludesFile を ${current_excludes} から ${excludes_path} に変更しました。%f"
+            msg_warn "core.excludesFile を ${current_excludes} から ${excludes_path} に変更しました。"
         else
-            print -P "情報: core.excludesFile に ${excludes_path} を設定しました。"
+            msg_info "core.excludesFile に ${excludes_path} を設定しました。"
         fi
     fi
 }
@@ -118,18 +114,18 @@ _git_show_user_guide() {
     user_email=$(git config --global user.email 2>/dev/null || true)
 
     if [[ -n "$user_name" && -n "$user_email" ]]; then
-        print -P ""
-        print -P "情報: Git ユーザー設定は既に構成されています。"
-        print -P "  user.name:  ${user_name}"
-        print -P "  user.email: ${user_email}"
+        printf '\n'
+        msg_info "Git ユーザー設定は既に構成されています。"
+        msg_step "user.name:  ${user_name}"
+        msg_step "user.email: ${user_email}"
     else
-        print -P ""
-        print -P "%F{220}NOTE: Git のユーザー情報が未設定です。以下を実行してください:%f"
+        printf '\n'
+        msg_warn "NOTE: Git のユーザー情報が未設定です。以下を実行してください:"
         if [[ -z "$user_name" ]]; then
-            print -P "  git config --global user.name \"Your Name\""
+            msg_step "git config --global user.name \"Your Name\""
         fi
         if [[ -z "$user_email" ]]; then
-            print -P "  git config --global user.email \"your@email.com\""
+            msg_step "git config --global user.email \"your@email.com\""
         fi
     fi
 }
@@ -144,13 +140,13 @@ uninstall_git() {
         local shared_path="$GIT_MOD_BASE_DIR/.gitconfig.shared"
         if git config --global --get-all include.path 2>/dev/null | grep -qF "$shared_path"; then
             if (( DRY_RUN )); then
-                print -P "%F{242}  [DRY-RUN] git config --global --fixed-value --unset-all include.path ${shared_path}%f"
+                msg_dry_run "git config --global --fixed-value --unset-all include.path ${shared_path}"
             else
                 if git config --global --fixed-value --unset-all include.path "$shared_path" 2>/dev/null; then
-                    print -P "情報: include.path から ${shared_path} を削除しました。"
+                    msg_info "include.path から ${shared_path} を削除しました。"
                 else
-                    print -P "%F{220}警告: include.path の解除に失敗しました。手動で確認してください:%f"
-                    print -P "  git config --global --edit"
+                    msg_warn "include.path の解除に失敗しました。手動で確認してください:"
+                    msg_step "git config --global --edit"
                 fi
             fi
             restored=1
@@ -162,51 +158,50 @@ uninstall_git() {
         current_excludes=$(git config --global core.excludesFile 2>/dev/null || true)
         if [[ "$current_excludes" == "$excludes_path" ]]; then
             if (( DRY_RUN )); then
-                print -P "%F{242}  [DRY-RUN] git config --global --unset core.excludesFile%f"
+                msg_dry_run "git config --global --unset core.excludesFile"
             else
                 if git config --global --unset core.excludesFile 2>/dev/null; then
-                    print -P "情報: core.excludesFile の設定を解除しました。"
+                    msg_info "core.excludesFile の設定を解除しました。"
                 else
-                    print -P "%F{220}警告: core.excludesFile の解除に失敗しました。手動で確認してください:%f"
-                    print -P "  git config --global --edit"
+                    msg_warn "core.excludesFile の解除に失敗しました。手動で確認してください:"
+                    msg_step "git config --global --edit"
                 fi
             fi
             restored=1
         fi
     else
-        print -P "%F{220}警告: git が見つかりません。git config の解除をスキップします。%f"
+        msg_warn "git が見つかりません。git config の解除をスキップします。"
     fi
 
     # 管理対象ファイルのバックアップ復元 / 削除
     for entry in "${GIT_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "削除: ${label} を削除します。"
+            printf '%s\n' "削除: ${label} を削除します。"
             run_cmd command rm -f "$dst" || {
-                print -P "%F{160}エラー: ${label} の削除に失敗しました。%f" >&2
+                msg_error "${label} の削除に失敗しました。"
                 return 1
             }
             restored=1
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Git グローバル設定のアンインストールが完了しました。%f"
+        msg_success "Git グローバル設定のアンインストールが完了しました。"
     else
-        print -P "情報: Git グローバル設定の復元・削除対象はありませんでした。"
+        msg_info "Git グローバル設定の復元・削除対象はありませんでした。"
     fi
 }

--- a/dotfiles/modules/git.sh
+++ b/dotfiles/modules/git.sh
@@ -22,7 +22,7 @@ GIT_MOD_MANAGED_FILES=(
 )
 
 # --- セットアップ ---
-module_setup() {
+setup_git() {
     print -P ""
     print -P "%F{36}%B[Git グローバル設定]%b%f"
     print -P "---------------------------------------------"
@@ -135,7 +135,7 @@ _git_show_user_guide() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_git() {
     local restored=0
 
     # git config の解除（git が利用可能な場合のみ）

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -25,9 +25,9 @@ MCLI_MOD_TOOLS=(
 # 戻り値: "macos" / "linux" / "unknown"
 _mcli_detect_os() {
     case "$OSTYPE" in
-        darwin*) print "macos" ;;
-        linux*)  print "linux" ;;
-        *)       print "unknown" ;;
+        darwin*) printf '%s' "macos" ;;
+        linux*)  printf '%s' "linux" ;;
+        *)       printf '%s' "unknown" ;;
     esac
 }
 
@@ -35,22 +35,22 @@ _mcli_detect_os() {
 # NOTE: DRY_RUN 時はパイプライン処理をスキップし、プレビュー表示のみ行う
 _mcli_install_eza_apt() {
     # 公式手順: https://github.com/eza-community/eza/blob/main/INSTALL.md
-    print -P "  eza の apt リポジトリを設定します..."
+    msg_step "eza の apt リポジトリを設定します..."
 
     # 前提コマンドの確認
     if ! command -v wget >/dev/null 2>&1; then
-        print -P "%F{160}エラー: wget がインストールされていません。%f" >&2
-        print -P "  sudo apt-get install wget で先にインストールしてください。" >&2
+        msg_error "wget がインストールされていません。"
+        msg_step "sudo apt-get install wget で先にインストールしてください。" >&2
         return 1
     fi
     if ! command -v gpg >/dev/null 2>&1; then
-        print -P "%F{160}エラー: gpg がインストールされていません。%f" >&2
-        print -P "  sudo apt-get install gnupg で先にインストールしてください。" >&2
+        msg_error "gpg がインストールされていません。"
+        msg_step "sudo apt-get install gnupg で先にインストールしてください。" >&2
         return 1
     fi
 
     run_cmd sudo mkdir -p /etc/apt/keyrings || {
-        print -P "%F{160}エラー: /etc/apt/keyrings の作成に失敗しました。%f" >&2
+        msg_error "/etc/apt/keyrings の作成に失敗しました。"
         return 1
     }
 
@@ -58,13 +58,13 @@ _mcli_install_eza_apt() {
         # GPG キーのダウンロードと変換を分離して個別にエラーチェック
         local tmp_key
         tmp_key=$(mktemp) || {
-            print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+            msg_error "一時ファイルの作成に失敗しました。"
             return 1
         }
 
         if ! wget -qO "$tmp_key" https://raw.githubusercontent.com/eza-community/eza/main/deb.asc; then
-            print -P "%F{160}エラー: eza の GPG キーのダウンロードに失敗しました。%f" >&2
-            print -P "  ネットワーク接続と URL の有効性を確認してください。" >&2
+            msg_error "eza の GPG キーのダウンロードに失敗しました。"
+            msg_step "ネットワーク接続と URL の有効性を確認してください。" >&2
             rm -f "$tmp_key"
             return 1
         fi
@@ -74,52 +74,51 @@ _mcli_install_eza_apt() {
 
         local gpg_err
         gpg_err=$(sudo gpg --dearmor -o /etc/apt/keyrings/eza.gpg "$tmp_key" 2>&1) || {
-            print -P "%F{160}エラー: eza の GPG キー変換に失敗しました。%f" >&2
-            [[ -n "$gpg_err" ]] && print -P "  詳細: ${gpg_err}" >&2
+            msg_error "eza の GPG キー変換に失敗しました。"
+            [[ -n "$gpg_err" ]] && msg_step "詳細: ${gpg_err}" >&2
             rm -f "$tmp_key"
             return 1
         }
         rm -f "$tmp_key"
 
         run_cmd sudo chmod 644 /etc/apt/keyrings/eza.gpg || {
-            print -P "%F{160}エラー: GPG キーファイルの権限設定に失敗しました。%f" >&2
+            msg_error "GPG キーファイルの権限設定に失敗しました。"
             return 1
         }
 
         # apt ソースの追加
         # NOTE: 公式リポジトリが HTTPS 未提供のため http を使用（GPG 署名で検証済み）
-        print "deb [signed-by=/etc/apt/keyrings/eza.gpg] http://deb.gierens.de stable main" \
+        printf '%s\n' "deb [signed-by=/etc/apt/keyrings/eza.gpg] http://deb.gierens.de stable main" \
             | sudo tee /etc/apt/sources.list.d/eza.list >/dev/null || {
-            print -P "%F{160}エラー: eza の apt ソース追加に失敗しました。%f" >&2
+            msg_error "eza の apt ソース追加に失敗しました。"
             return 1
         }
         run_cmd sudo chmod 644 /etc/apt/sources.list.d/eza.list || {
-            print -P "%F{160}エラー: apt ソースファイルの権限設定に失敗しました。%f" >&2
+            msg_error "apt ソースファイルの権限設定に失敗しました。"
             return 1
         }
     else
-        print -P "%F{242}  [DRY-RUN] wget -qO /tmp/... https://...eza.../deb.asc%f"
-        print -P "%F{242}  [DRY-RUN] sudo gpg --dearmor -o /etc/apt/keyrings/eza.gpg /tmp/...%f"
-        print -P "%F{242}  [DRY-RUN] sudo chmod 644 /etc/apt/keyrings/eza.gpg%f"
-        print -P "%F{242}  [DRY-RUN] echo 'deb ...' | sudo tee /etc/apt/sources.list.d/eza.list%f"
-        print -P "%F{242}  [DRY-RUN] sudo chmod 644 /etc/apt/sources.list.d/eza.list%f"
+        msg_dry_run "wget -qO /tmp/... https://...eza.../deb.asc"
+        msg_dry_run "sudo gpg --dearmor -o /etc/apt/keyrings/eza.gpg /tmp/..."
+        msg_dry_run "sudo chmod 644 /etc/apt/keyrings/eza.gpg"
+        msg_dry_run "echo 'deb ...' | sudo tee /etc/apt/sources.list.d/eza.list"
+        msg_dry_run "sudo chmod 644 /etc/apt/sources.list.d/eza.list"
     fi
 
     run_cmd sudo apt-get update -qq || {
-        print -P "%F{220}警告: apt update に失敗しました。%f"
-        print -P "  新しい apt リポジトリの情報を取得できなかったため、eza のインストールに失敗する可能性があります。"
+        msg_warn "apt update に失敗しました。"
+        msg_step "新しい apt リポジトリの情報を取得できなかったため、eza のインストールに失敗する可能性があります。"
     }
     run_cmd sudo apt-get install -y eza || {
-        print -P "%F{160}エラー: eza のインストールに失敗しました。%f" >&2
+        msg_error "eza のインストールに失敗しました。"
         return 1
     }
 }
 
 # --- セットアップ ---
 setup_modern_cli() {
-    print -P ""
-    print -P "%F{36}%B[モダン CLI ツール]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "モダン CLI ツール"
+    print_separator
 
     local os
     os=$(_mcli_detect_os)
@@ -128,30 +127,27 @@ setup_modern_cli() {
     case "$os" in
         macos)
             if ! command -v brew >/dev/null 2>&1; then
-                print -P "%F{160}エラー: Homebrew がインストールされていません。%f" >&2
-                print -P "  インストール: https://brew.sh/" >&2
+                msg_error "Homebrew がインストールされていません。"
+                msg_step "インストール: https://brew.sh/" >&2
                 return 1
             fi
             ;;
         linux)
             if ! command -v apt-get >/dev/null 2>&1; then
-                print -P "%F{160}エラー: apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。%f" >&2
+                msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
                 return 1
             fi
             ;;
         *)
-            print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+            msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
             return 1
             ;;
     esac
 
-    typeset -i installed=0 skipped=0 failed=0
+    declare -i installed=0 skipped=0 failed=0
 
     for tool_entry in "${MCLI_MOD_TOOLS[@]}"; do
-        local cmd_name="${tool_entry[(ws:|:)1]}"
-        local brew_pkg="${tool_entry[(ws:|:)2]}"
-        local apt_pkg="${tool_entry[(ws:|:)3]}"
-        local desc="${tool_entry[(ws:|:)4]}"
+        IFS='|' read -r cmd_name brew_pkg apt_pkg desc <<< "$tool_entry"
 
         # Ubuntu の別名バイナリも確認（batcat, fdfind）
         local alt_cmd=""
@@ -160,22 +156,22 @@ setup_modern_cli() {
 
         # べき等性チェック
         if command -v "$cmd_name" >/dev/null 2>&1; then
-            print -P "情報: ${cmd_name} は既にインストールされています。スキップします。"
+            msg_info "${cmd_name} は既にインストールされています。スキップします。"
             (( skipped++ ))
             continue
         fi
         if [[ -n "$alt_cmd" ]] && command -v "$alt_cmd" >/dev/null 2>&1; then
-            print -P "情報: ${alt_cmd} (${cmd_name}) は既にインストールされています。スキップします。"
+            msg_info "${alt_cmd} (${cmd_name}) は既にインストールされています。スキップします。"
             (( skipped++ ))
             continue
         fi
 
-        print -P "${cmd_name} をインストールします... (${desc})"
+        printf '%s\n' "${cmd_name} をインストールします... (${desc})"
 
         case "$os" in
             macos)
                 run_cmd brew install "$brew_pkg" || {
-                    print -P "%F{160}エラー: ${cmd_name} のインストールに失敗しました。%f" >&2
+                    msg_error "${cmd_name} のインストールに失敗しました。"
                     (( failed++ ))
                     continue
                 }
@@ -189,7 +185,7 @@ setup_modern_cli() {
                     }
                 else
                     run_cmd sudo apt-get install -y "$apt_pkg" || {
-                        print -P "%F{160}エラー: ${cmd_name} (${apt_pkg}) のインストールに失敗しました。%f" >&2
+                        msg_error "${cmd_name} (${apt_pkg}) のインストールに失敗しました。"
                         (( failed++ ))
                         continue
                     }
@@ -201,18 +197,18 @@ setup_modern_cli() {
     done
 
     # サマリー表示
-    print -P ""
+    printf '\n'
     if (( failed > 0 )); then
-        print -P "%F{220}モダン CLI ツール: ${installed} 件インストール, ${skipped} 件スキップ, %F{160}${failed} 件失敗%f"
+        msg_warn "モダン CLI ツール: ${installed} 件インストール, ${skipped} 件スキップ, ${failed} 件失敗"
         return 1
     elif (( DRY_RUN )); then
-        print -P "情報: モダン CLI ツールをインストール予定です（dry-run）。"
+        msg_info "モダン CLI ツールをインストール予定です（dry-run）。"
     else
-        print -P "%F{34}モダン CLI ツール: ${installed} 件インストール, ${skipped} 件スキップ%f"
+        msg_success "モダン CLI ツール: ${installed} 件インストール, ${skipped} 件スキップ"
         if (( installed > 0 )); then
-            print -P ""
-            print -P "エイリアス設定は aliases.zsh に含まれています。"
-            print -P "シェルを再起動すると自動的に有効になります。"
+            printf '\n'
+            printf '%s\n' "エイリアス設定は aliases.zsh に含まれています。"
+            printf '%s\n' "シェルを再起動すると自動的に有効になります。"
         fi
     fi
 }
@@ -220,24 +216,24 @@ setup_modern_cli() {
 # --- アンインストール ---
 # NOTE: システムパッケージの自動削除は意図しない依存破壊のリスクがあるため、手順の表示のみとする
 uninstall_modern_cli() {
-    print -P "モダン CLI ツールのアンインストール手順:"
-    print -P ""
+    printf '%s\n' "モダン CLI ツールのアンインストール手順:"
+    printf '\n'
 
     local os
     os=$(_mcli_detect_os)
 
     case "$os" in
         macos)
-            print -P "  brew uninstall eza bat fd ripgrep"
+            msg_step "brew uninstall eza bat fd ripgrep"
             ;;
         linux)
-            print -P "  sudo apt-get remove eza bat fd-find ripgrep"
-            print -P "  # eza の apt ソースも削除する場合:"
-            print -P "  sudo rm -f /etc/apt/sources.list.d/eza.list"
-            print -P "  sudo rm -f /etc/apt/keyrings/eza.gpg"
+            msg_step "sudo apt-get remove eza bat fd-find ripgrep"
+            msg_step "# eza の apt ソースも削除する場合:"
+            msg_step "sudo rm -f /etc/apt/sources.list.d/eza.list"
+            msg_step "sudo rm -f /etc/apt/keyrings/eza.gpg"
             ;;
         *)
-            print -P "  OS に応じたパッケージマネージャーで削除してください。"
+            msg_step "OS に応じたパッケージマネージャーで削除してください。"
             ;;
     esac
 }

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -116,7 +116,7 @@ _mcli_install_eza_apt() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_modern_cli() {
     print -P ""
     print -P "%F{36}%B[モダン CLI ツール]%b%f"
     print -P "---------------------------------------------"
@@ -219,7 +219,7 @@ module_setup() {
 
 # --- アンインストール ---
 # NOTE: システムパッケージの自動削除は意図しない依存破壊のリスクがあるため、手順の表示のみとする
-module_uninstall() {
+uninstall_modern_cli() {
     print -P "モダン CLI ツールのアンインストール手順:"
     print -P ""
 

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -25,34 +25,33 @@ NODE_MOD_MANAGED_FILES=(
 # --- ヘルパー: OS 判定 ---
 _node_detect_os() {
     case "$OSTYPE" in
-        darwin*) print "macos" ;;
-        linux*)  print "linux" ;;
-        *)       print "unknown" ;;
+        darwin*) printf '%s' "macos" ;;
+        linux*)  printf '%s' "linux" ;;
+        *)       printf '%s' "unknown" ;;
     esac
 }
 
 # --- ヘルパー: アーキテクチャ判定 ---
 _node_detect_arch() {
     case "$(uname -m)" in
-        x86_64)  print "x64" ;;
-        aarch64) print "arm64" ;;
-        arm64)   print "arm64" ;;
-        *)       print "unknown" ;;
+        x86_64)  printf '%s' "x64" ;;
+        aarch64) printf '%s' "arm64" ;;
+        arm64)   printf '%s' "arm64" ;;
+        *)       printf '%s' "unknown" ;;
     esac
 }
 
 # --- セットアップ ---
 setup_node() {
-    print -P ""
-    print -P "%F{36}%B[Node.js 開発環境]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Node.js 開発環境"
+    print_separator
 
     # べき等性チェック
     local fnm_exists=0
     if command -v fnm >/dev/null 2>&1; then
         local current_ver
-        current_ver=$(fnm --version 2>/dev/null || print "unknown")
-        print -P "情報: fnm は既にインストールされています (${current_ver})。スキップします。"
+        current_ver=$(fnm --version 2>/dev/null || printf '%s' "unknown")
+        msg_info "fnm は既にインストールされています (${current_ver})。スキップします。"
         fnm_exists=1
     fi
 
@@ -68,7 +67,7 @@ setup_node() {
                 _node_setup_linux || return 1
                 ;;
             *)
-                print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+                msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
                 return 1
                 ;;
         esac
@@ -84,8 +83,8 @@ setup_node() {
 
     # Node.js LTS のインストール（失敗しても fnm 自体は利用可能なので警告に留める）
     _node_install_lts || {
-        print -P "%F{220}警告: Node.js LTS のインストールに失敗しましたが、fnm は利用可能です。%f"
-        print -P "  手動でインストールしてください: fnm install --lts"
+        msg_warn "Node.js LTS のインストールに失敗しましたが、fnm は利用可能です。"
+        msg_step "手動でインストールしてください: fnm install --lts"
     }
 
     # 設定ファイルの配置
@@ -95,32 +94,32 @@ setup_node() {
     (( ! DRY_RUN )) && hash -r
 
     if (( DRY_RUN )); then
-        print -P "情報: Node.js 開発環境をセットアップ予定です（dry-run）。"
+        msg_info "Node.js 開発環境をセットアップ予定です（dry-run）。"
     else
-        print -P "%F{34}Node.js 開発環境のセットアップが完了しました。%f"
+        msg_success "Node.js 開発環境のセットアップが完了しました。"
         if command -v node >/dev/null 2>&1; then
-            print -P "  Node.js: $(node -v 2>/dev/null || print 'N/A')"
-            print -P "  npm: $(npm -v 2>/dev/null || print 'N/A')"
+            msg_step "Node.js: $(node -v 2>/dev/null || printf '%s' 'N/A')"
+            msg_step "npm: $(npm -v 2>/dev/null || printf '%s' 'N/A')"
         fi
-        print -P ""
-        print -P "使い方:"
-        print -P "  fnm install 22            # 特定バージョンをインストール"
-        print -P "  fnm use 22                # バージョンを切り替え"
-        print -P "  fnm default 22            # デフォルトバージョンを設定"
+        printf '\n'
+        printf '%s\n' "使い方:"
+        msg_step "fnm install 22            # 特定バージョンをインストール"
+        msg_step "fnm use 22                # バージョンを切り替え"
+        msg_step "fnm default 22            # デフォルトバージョンを設定"
     fi
 }
 
 # --- macOS セットアップ ---
 _node_setup_macos() {
     if ! command -v brew >/dev/null 2>&1; then
-        print -P "%F{160}エラー: Homebrew がインストールされていません。%f" >&2
-        print -P "  インストール: https://brew.sh/" >&2
+        msg_error "Homebrew がインストールされていません。"
+        msg_step "インストール: https://brew.sh/" >&2
         return 1
     fi
 
-    print -P "fnm を Homebrew でインストールします..."
+    msg_info "fnm を Homebrew でインストールします..."
     run_cmd brew install fnm || {
-        print -P "%F{160}エラー: fnm のインストールに失敗しました。%f" >&2
+        msg_error "fnm のインストールに失敗しました。"
         return 1
     }
 }
@@ -136,17 +135,17 @@ _node_setup_linux() {
     done
 
     if (( ${#missing_cmds[@]} > 0 )); then
-        print -P "${missing_cmds[*]} をインストールします..."
+        printf '%s\n' "${missing_cmds[*]} をインストールします..."
         if command -v apt-get >/dev/null 2>&1; then
             run_cmd sudo apt-get update -qq || {
-                print -P "%F{220}警告: apt update に失敗しました。後続のインストールに失敗する可能性があります。%f"
+                msg_warn "apt update に失敗しました。後続のインストールに失敗する可能性があります。"
             }
             run_cmd sudo apt-get install -y "${missing_cmds[@]}" || {
-                print -P "%F{160}エラー: ${missing_cmds[*]} のインストールに失敗しました。%f" >&2
+                msg_error "${missing_cmds[*]} のインストールに失敗しました。"
                 return 1
             }
         else
-            print -P "%F{160}エラー: ${missing_cmds[*]} がインストールされていません。手動でインストールしてください。%f" >&2
+            msg_error "${missing_cmds[*]} がインストールされていません。手動でインストールしてください。"
             return 1
         fi
     fi
@@ -155,7 +154,7 @@ _node_setup_linux() {
     local arch
     arch=$(_node_detect_arch)
     if [[ "$arch" == "unknown" ]]; then
-        print -P "%F{160}エラー: 未対応のアーキテクチャです ($(uname -m))。%f" >&2
+        msg_error "未対応のアーキテクチャです ($(uname -m))。"
         return 1
     fi
 
@@ -165,46 +164,46 @@ _node_setup_linux() {
     # バイナリ配置先の作成
     if [[ ! -d "$NODE_MOD_FNM_BIN_DIR" ]]; then
         run_cmd command mkdir -p "$NODE_MOD_FNM_BIN_DIR" || {
-            print -P "%F{160}エラー: $NODE_MOD_FNM_BIN_DIR の作成に失敗しました。%f" >&2
+            msg_error "$NODE_MOD_FNM_BIN_DIR の作成に失敗しました。"
             return 1
         }
     fi
 
     # 不完全なインストールの検出
     if [[ -f "$NODE_MOD_FNM_BIN_DIR/fnm" && ! -x "$NODE_MOD_FNM_BIN_DIR/fnm" ]]; then
-        print -P "%F{220}警告: fnm バイナリは存在しますが実行権限がありません。再インストールします。%f"
+        msg_warn "fnm バイナリは存在しますが実行権限がありません。再インストールします。"
         run_cmd command rm -f "$NODE_MOD_FNM_BIN_DIR/fnm" || {
-            print -P "%F{160}エラー: 既存の fnm バイナリの削除に失敗しました。%f" >&2
-            print -P "  手動で削除してください: rm -f $NODE_MOD_FNM_BIN_DIR/fnm" >&2
+            msg_error "既存の fnm バイナリの削除に失敗しました。"
+            msg_step "手動で削除してください: rm -f $NODE_MOD_FNM_BIN_DIR/fnm" >&2
             return 1
         }
     fi
 
-    print -P "fnm を GitHub Releases からダウンロードします (${arch})..."
+    msg_info "fnm を GitHub Releases からダウンロードします (${arch})..."
 
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] curl -fsSL ${download_url} -o /tmp/${zip_name}%f"
-        print -P "%F{242}  [DRY-RUN] unzip -o /tmp/${zip_name} -d ${NODE_MOD_FNM_BIN_DIR}%f"
-        print -P "%F{242}  [DRY-RUN] chmod +x ${NODE_MOD_FNM_BIN_DIR}/fnm%f"
+        msg_dry_run "curl -fsSL ${download_url} -o /tmp/${zip_name}"
+        msg_dry_run "unzip -o /tmp/${zip_name} -d ${NODE_MOD_FNM_BIN_DIR}"
+        msg_dry_run "chmod +x ${NODE_MOD_FNM_BIN_DIR}/fnm"
     else
         # 安全な一時ファイルの作成（予測可能なパスを避ける）
         local tmp_zip
         tmp_zip=$(mktemp /tmp/fnm-XXXXXXXXXX.zip) || {
-            print -P "%F{160}エラー: 一時ファイルの作成に失敗しました。%f" >&2
+            msg_error "一時ファイルの作成に失敗しました。"
             return 1
         }
 
         # ダウンロード
         curl -fsSL "$download_url" -o "$tmp_zip" || {
-            print -P "%F{160}エラー: fnm のダウンロードに失敗しました。%f" >&2
-            print -P "  URL: ${download_url}" >&2
+            msg_error "fnm のダウンロードに失敗しました。"
+            printf '%s\n' "  URL: ${download_url}" >&2
             rm -f "$tmp_zip"
             return 1
         }
 
         # 解凍
         unzip -o "$tmp_zip" -d "$NODE_MOD_FNM_BIN_DIR" || {
-            print -P "%F{160}エラー: fnm の解凍に失敗しました。%f" >&2
+            msg_error "fnm の解凍に失敗しました。"
             rm -f "$tmp_zip"
             return 1
         }
@@ -212,7 +211,7 @@ _node_setup_linux() {
 
         # 実行権限の付与
         chmod +x "$NODE_MOD_FNM_BIN_DIR/fnm" || {
-            print -P "%F{160}エラー: fnm の実行権限の付与に失敗しました。%f" >&2
+            msg_error "fnm の実行権限の付与に失敗しました。"
             return 1
         }
     fi
@@ -221,13 +220,13 @@ _node_setup_linux() {
 # --- Node.js LTS インストール ---
 _node_install_lts() {
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] fnm install --lts%f"
-        print -P "%F{242}  [DRY-RUN] fnm default lts-latest%f"
+        msg_dry_run "fnm install --lts"
+        msg_dry_run "fnm default lts-latest"
         return 0
     fi
 
     if ! command -v fnm >/dev/null 2>&1; then
-        print -P "%F{220}警告: fnm が PATH に見つかりません。Node.js LTS のインストールをスキップします。%f"
+        msg_warn "fnm が PATH に見つかりません。Node.js LTS のインストールをスキップします。"
         return 0
     fi
 
@@ -241,26 +240,26 @@ _node_install_lts() {
             node_major="${node_major%%.*}"
         fi
 
-        if [[ "$node_major" == <-> ]] && (( node_major >= 18 )); then
-            print -P "情報: Node.js は既にインストールされています (${node_ver})。スキップします。"
+        if [[ "$node_major" =~ ^[0-9]+$ ]] && (( node_major >= 18 )); then
+            msg_info "Node.js は既にインストールされています (${node_ver})。スキップします。"
             return 0
-        elif [[ "$node_major" == <-> ]] && (( node_major < 18 )); then
-            print -P "%F{220}警告: 既存の Node.js (${node_ver}) は推奨バージョン (v18 以上) 未満です。fnm で LTS をインストールします。%f"
+        elif [[ "$node_major" =~ ^[0-9]+$ ]] && (( node_major < 18 )); then
+            msg_warn "既存の Node.js (${node_ver}) は推奨バージョン (v18 以上) 未満です。fnm で LTS をインストールします。"
         else
-            print -P "%F{220}警告: Node.js のバージョンを特定できません (${node_ver:-unknown})。fnm で LTS をインストールします。%f"
+            msg_warn "Node.js のバージョンを特定できません (${node_ver:-unknown})。fnm で LTS をインストールします。"
         fi
     fi
 
-    print -P "Node.js LTS をインストールします..."
+    msg_info "Node.js LTS をインストールします..."
     fnm install --lts || {
-        print -P "%F{160}エラー: Node.js LTS のインストールに失敗しました。%f" >&2
-        print -P "  手動でインストールしてください: fnm install --lts" >&2
+        msg_error "Node.js LTS のインストールに失敗しました。"
+        msg_step "手動でインストールしてください: fnm install --lts" >&2
         return 1
     }
 
     # デフォルトバージョンに設定
     fnm default lts-latest 2>/dev/null || {
-        print -P "%F{220}警告: デフォルトバージョンの設定に失敗しました。%f"
+        msg_warn "デフォルトバージョンの設定に失敗しました。"
     }
 
     # fnm env を再評価して node を PATH に通す
@@ -269,12 +268,9 @@ _node_install_lts() {
 
 # --- 設定ファイル配置ヘルパー ---
 _node_install_config() {
-    print -P "設定ファイルを配置します..."
+    msg_info "設定ファイルを配置します..."
     for entry in "${NODE_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 }
@@ -284,48 +280,47 @@ uninstall_node() {
     local restored=0
 
     for entry in "${NODE_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "削除: ${label} を削除します。"
+            printf '%s\n' "削除: ${label} を削除します。"
             run_cmd command rm -f "$dst" || {
-                print -P "%F{160}エラー: ${label} の削除に失敗しました。%f" >&2
+                msg_error "${label} の削除に失敗しました。"
                 return 1
             }
             restored=1
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Node.js 開発環境の設定を削除しました。%f"
+        msg_success "Node.js 開発環境の設定を削除しました。"
     else
-        print -P "情報: Node.js 開発環境の復元・削除対象はありませんでした。"
+        msg_info "Node.js 開発環境の復元・削除対象はありませんでした。"
     fi
 
-    print -P ""
-    print -P "NOTE: fnm 本体と Node.js バージョンは削除されていません。不要な場合は以下を手動で削除してください:"
+    printf '\n'
+    printf '%s\n' "NOTE: fnm 本体と Node.js バージョンは削除されていません。不要な場合は以下を手動で削除してください:"
     local os
     os=$(_node_detect_os)
     case "$os" in
         macos)
-            print -P "  brew uninstall fnm"
+            msg_step "brew uninstall fnm"
             ;;
         *)
-            print -P "  rm -f ${NODE_MOD_FNM_BIN_DIR}/fnm"
+            msg_step "rm -f ${NODE_MOD_FNM_BIN_DIR}/fnm"
             ;;
     esac
-    print -P "  rm -rf ${XDG_DATA_HOME:-$HOME/.local/share}/fnm"
+    msg_step "rm -rf ${XDG_DATA_HOME:-$HOME/.local/share}/fnm"
 }

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -42,7 +42,7 @@ _node_detect_arch() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_node() {
     print -P ""
     print -P "%F{36}%B[Node.js 開発環境]%b%f"
     print -P "---------------------------------------------"
@@ -280,7 +280,7 @@ _node_install_config() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_node() {
     local restored=0
 
     for entry in "${NODE_MOD_MANAGED_FILES[@]}"; do

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -50,7 +50,7 @@ _py_detect_os() {
 }
 
 # --- セットアップ ---
-module_setup() {
+setup_python() {
     print -P ""
     print -P "%F{36}%B[Python 開発環境]%b%f"
     print -P "---------------------------------------------"
@@ -185,7 +185,7 @@ _py_install_config() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_python() {
     local restored=0
 
     for entry in "${PY_MOD_MANAGED_FILES[@]}"; do

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -43,23 +43,22 @@ PY_MOD_MANAGED_FILES=(
 # --- ヘルパー: OS 判定 ---
 _py_detect_os() {
     case "$OSTYPE" in
-        darwin*) print "macos" ;;
-        linux*)  print "linux" ;;
-        *)       print "unknown" ;;
+        darwin*) printf '%s' "macos" ;;
+        linux*)  printf '%s' "linux" ;;
+        *)       printf '%s' "unknown" ;;
     esac
 }
 
 # --- セットアップ ---
 setup_python() {
-    print -P ""
-    print -P "%F{36}%B[Python 開発環境]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Python 開発環境"
+    print_separator
 
     # べき等性チェック
     if command -v pyenv >/dev/null 2>&1; then
         local current_ver
-        current_ver=$(pyenv --version 2>/dev/null || print "unknown")
-        print -P "情報: pyenv は既にインストールされています (${current_ver})。スキップします。"
+        current_ver=$(pyenv --version 2>/dev/null || printf '%s' "unknown")
+        msg_info "pyenv は既にインストールされています (${current_ver})。スキップします。"
         # 設定ファイルのみ更新確認
         _py_install_config
         return 0
@@ -76,7 +75,7 @@ setup_python() {
             _py_setup_linux || return 1
             ;;
         *)
-            print -P "%F{160}エラー: 未対応の OS です (OSTYPE=${OSTYPE})。%f" >&2
+            msg_error "未対応の OS です (OSTYPE=${OSTYPE})。"
             return 1
             ;;
     esac
@@ -85,56 +84,56 @@ setup_python() {
     _py_install_config
 
     if (( DRY_RUN )); then
-        print -P "情報: Python 開発環境をセットアップ予定です（dry-run）。"
+        msg_info "Python 開発環境をセットアップ予定です（dry-run）。"
     else
-        print -P "%F{34}Python 開発環境のセットアップが完了しました。%f"
-        print -P ""
-        print -P "次のステップ:"
-        print -P "  exec zsh                    # シェルを再起動"
-        print -P "  pyenv install 3.13.2        # Python をインストール"
-        print -P "  pyenv global 3.13.2         # デフォルトバージョンを設定"
+        msg_success "Python 開発環境のセットアップが完了しました。"
+        printf '\n'
+        printf '%s\n' "次のステップ:"
+        msg_step "exec zsh                    # シェルを再起動"
+        msg_step "pyenv install 3.13.2        # Python をインストール"
+        msg_step "pyenv global 3.13.2         # デフォルトバージョンを設定"
     fi
 }
 
 # --- macOS セットアップ ---
 _py_setup_macos() {
     if ! command -v brew >/dev/null 2>&1; then
-        print -P "%F{160}エラー: Homebrew がインストールされていません。%f" >&2
-        print -P "  インストール: https://brew.sh/" >&2
+        msg_error "Homebrew がインストールされていません。"
+        msg_step "インストール: https://brew.sh/" >&2
         return 1
     fi
 
-    print -P "pyenv を Homebrew でインストールします..."
+    msg_info "pyenv を Homebrew でインストールします..."
     run_cmd brew install pyenv || {
-        print -P "%F{160}エラー: pyenv のインストールに失敗しました。%f" >&2
+        msg_error "pyenv のインストールに失敗しました。"
         return 1
     }
 
-    print -P "pyenv-virtualenv を Homebrew でインストールします..."
+    msg_info "pyenv-virtualenv を Homebrew でインストールします..."
     run_cmd brew install pyenv-virtualenv || {
-        print -P "%F{220}警告: pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。%f"
+        msg_warn "pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。"
     }
 }
 
 # --- Linux セットアップ ---
 _py_setup_linux() {
     if ! command -v apt-get >/dev/null 2>&1; then
-        print -P "%F{160}エラー: apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。%f" >&2
+        msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
         return 1
     fi
 
     if ! command -v git >/dev/null 2>&1; then
-        print -P "%F{160}エラー: git がインストールされていません。%f" >&2
+        msg_error "git がインストールされていません。"
         return 1
     fi
 
     # ビルド依存パッケージのインストール
-    print -P "Python ビルド依存パッケージをインストールします..."
+    msg_info "Python ビルド依存パッケージをインストールします..."
     run_cmd sudo apt-get update -qq || {
-        print -P "%F{220}警告: apt update に失敗しました。後続のパッケージインストールに失敗する可能性があります。%f"
+        msg_warn "apt update に失敗しました。後続のパッケージインストールに失敗する可能性があります。"
     }
     run_cmd sudo apt-get install -y "${PY_MOD_DEPS[@]}" || {
-        print -P "%F{160}エラー: ビルド依存パッケージのインストールに失敗しました。%f" >&2
+        msg_error "ビルド依存パッケージのインストールに失敗しました。"
         return 1
     }
 
@@ -142,20 +141,20 @@ _py_setup_linux() {
     if [[ -d "$PY_MOD_PYENV_ROOT" ]]; then
         # 不完全なクローンの検出（前回の git clone が途中で失敗した場合）
         if [[ ! -x "$PY_MOD_PYENV_ROOT/bin/pyenv" && ! -x "$PY_MOD_PYENV_ROOT/libexec/pyenv" ]]; then
-            print -P "%F{220}警告: $PY_MOD_PYENV_ROOT は存在しますが不完全です。再インストールします。%f"
+            msg_warn "$PY_MOD_PYENV_ROOT は存在しますが不完全です。再インストールします。"
             run_cmd command rm -rf "$PY_MOD_PYENV_ROOT" || {
-                print -P "%F{160}エラー: 不完全な pyenv ディレクトリの削除に失敗しました。%f" >&2
-                print -P "  手動で削除してください: rm -rf $PY_MOD_PYENV_ROOT" >&2
+                msg_error "不完全な pyenv ディレクトリの削除に失敗しました。"
+                msg_step "手動で削除してください: rm -rf $PY_MOD_PYENV_ROOT" >&2
                 return 1
             }
         else
-            print -P "情報: $PY_MOD_PYENV_ROOT は既に存在します。スキップします。"
+            msg_info "$PY_MOD_PYENV_ROOT は既に存在します。スキップします。"
         fi
     fi
     if [[ ! -d "$PY_MOD_PYENV_ROOT" ]]; then
-        print -P "pyenv を git clone でインストールします..."
+        msg_info "pyenv を git clone でインストールします..."
         run_cmd git clone --depth 1 "$PY_MOD_PYENV_REPO" "$PY_MOD_PYENV_ROOT" || {
-            print -P "%F{160}エラー: pyenv の git clone に失敗しました。%f" >&2
+            msg_error "pyenv の git clone に失敗しました。"
             return 1
         }
     fi
@@ -163,23 +162,20 @@ _py_setup_linux() {
     # pyenv-virtualenv のインストール
     local virtualenv_dir="$PY_MOD_PYENV_ROOT/plugins/pyenv-virtualenv"
     if [[ -d "$virtualenv_dir" ]]; then
-        print -P "情報: pyenv-virtualenv は既にインストールされています。スキップします。"
+        msg_info "pyenv-virtualenv は既にインストールされています。スキップします。"
     else
-        print -P "pyenv-virtualenv を git clone でインストールします..."
+        msg_info "pyenv-virtualenv を git clone でインストールします..."
         run_cmd git clone --depth 1 "$PY_MOD_VIRTUALENV_REPO" "$virtualenv_dir" || {
-            print -P "%F{220}警告: pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。%f"
+            msg_warn "pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。"
         }
     fi
 }
 
 # --- 設定ファイル配置ヘルパー ---
 _py_install_config() {
-    print -P "設定ファイルを配置します..."
+    msg_info "設定ファイルを配置します..."
     for entry in "${PY_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 }
@@ -189,42 +185,41 @@ uninstall_python() {
     local restored=0
 
     for entry in "${PY_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "削除: ${label} を削除します。"
+            printf '%s\n' "削除: ${label} を削除します。"
             run_cmd command rm -f "$dst" || {
-                print -P "%F{160}エラー: ${label} の削除に失敗しました。%f" >&2
+                msg_error "${label} の削除に失敗しました。"
                 return 1
             }
             restored=1
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Python 開発環境の設定を削除しました。%f"
+        msg_success "Python 開発環境の設定を削除しました。"
     else
-        print -P "情報: Python 開発環境の復元・削除対象はありませんでした。"
+        msg_info "Python 開発環境の復元・削除対象はありませんでした。"
     fi
 
-    print -P ""
-    print -P "NOTE: pyenv 本体は削除されていません。不要な場合は以下を手動で削除してください:"
-    print -P "  rm -rf ${PY_MOD_PYENV_ROOT}"
+    printf '\n'
+    printf '%s\n' "NOTE: pyenv 本体は削除されていません。不要な場合は以下を手動で削除してください:"
+    msg_step "rm -rf ${PY_MOD_PYENV_ROOT}"
     if command -v brew >/dev/null 2>&1; then
-        print -P "  # macOS の場合:"
-        print -P "  brew uninstall pyenv pyenv-virtualenv"
+        msg_step "# macOS の場合:"
+        msg_step "brew uninstall pyenv pyenv-virtualenv"
     fi
 }

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -27,7 +27,7 @@ ZSH_MOD_MANAGED_FILES=(
 )
 
 # --- セットアップ ---
-module_setup() {
+setup_zsh() {
     print -P ""
     print -P "%F{36}%B[Zsh 設定一式]%b%f"
     print -P "---------------------------------------------"
@@ -89,7 +89,7 @@ module_setup() {
 }
 
 # --- アンインストール ---
-module_uninstall() {
+uninstall_zsh() {
     local restored=0
 
     for entry in "${ZSH_MOD_MANAGED_FILES[@]}"; do

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -28,64 +28,60 @@ ZSH_MOD_MANAGED_FILES=(
 
 # --- セットアップ ---
 setup_zsh() {
-    print -P ""
-    print -P "%F{36}%B[Zsh 設定一式]%b%f"
-    print -P "---------------------------------------------"
+    msg_header "Zsh 設定一式"
+    print_separator
 
     # 依存コマンドの確認
     if ! command -v git >/dev/null 2>&1; then
-        print -P "%F{160}エラー: git コマンドが見つかりません。インストールしてください。%f" >&2
+        msg_error "git コマンドが見つかりません。インストールしてください。"
         return 1
     fi
-    print -P "情報: git が利用可能です ($(command git --version))"
+    msg_info "git が利用可能です ($(command git --version))"
 
     # Zinit のインストール
-    print -P "Zinit の状態を確認・インストールします..."
+    msg_info "Zinit の状態を確認・インストールします..."
     if [[ ! -f "$ZSH_MOD_ZINIT_HOME/zinit.zsh" ]]; then
-        print -P "%F{33} %F{220}Zinit (%F{33}zdharma-continuum/zinit%F{220}) をインストール中...%f"
+        color_print "${C_YELLOW}" "Zinit (zdharma-continuum/zinit) をインストール中..."
         run_cmd command mkdir -p -m 700 "$(dirname "$ZSH_MOD_ZINIT_HOME")" || {
-            print -P "%F{160}エラー: Zinit 用ディレクトリの作成に失敗しました。%f" >&2
+            msg_error "Zinit 用ディレクトリの作成に失敗しました。"
             return 1
         }
         run_cmd command git clone --branch "$ZSH_MOD_ZINIT_VERSION" --depth 1 https://github.com/zdharma-continuum/zinit "$ZSH_MOD_ZINIT_HOME" || {
-            print -P "%F{160}エラー: Zinit の git clone に失敗しました。%f" >&2
+            msg_error "Zinit の git clone に失敗しました。"
             return 1
         }
         if (( DRY_RUN )); then
-            print -P "情報: Zinit ${ZSH_MOD_ZINIT_VERSION} をインストール予定です（dry-run）。"
+            msg_info "Zinit ${ZSH_MOD_ZINIT_VERSION} をインストール予定です（dry-run）。"
         else
-            print -P "%F{33} %F{34}Zinit ${ZSH_MOD_ZINIT_VERSION} のインストールに成功しました。%f"
+            msg_success "Zinit ${ZSH_MOD_ZINIT_VERSION} のインストールに成功しました。"
         fi
     else
-        print -P "情報: Zinit は既にインストールされています。"
+        msg_info "Zinit は既にインストールされています。"
     fi
 
     # 設定ディレクトリの作成
     if [[ ! -d "$ZSH_MOD_CONFIG_DIR" ]]; then
         run_cmd command mkdir -p -m 700 "$ZSH_MOD_CONFIG_DIR" || {
-            print -P "%F{160}エラー: $ZSH_MOD_CONFIG_DIR の作成に失敗しました。%f" >&2
+            msg_error "$ZSH_MOD_CONFIG_DIR の作成に失敗しました。"
             return 1
         }
         if (( DRY_RUN )); then
-            print -P "情報: $ZSH_MOD_CONFIG_DIR を作成予定です（dry-run）。"
+            msg_info "$ZSH_MOD_CONFIG_DIR を作成予定です（dry-run）。"
         else
-            print -P "情報: $ZSH_MOD_CONFIG_DIR を作成しました。"
+            msg_info "$ZSH_MOD_CONFIG_DIR を作成しました。"
         fi
     else
-        print -P "情報: $ZSH_MOD_CONFIG_DIR は既に存在します。"
+        msg_info "$ZSH_MOD_CONFIG_DIR は既に存在します。"
     fi
 
     # 設定ファイルの配置
-    print -P "設定ファイルを配置します..."
+    msg_info "設定ファイルを配置します..."
     for entry in "${ZSH_MOD_MANAGED_FILES[@]}"; do
-        local src="${entry[(ws:|:)1]}"
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
-        local hint="${entry[(ws:|:)4]}"
+        IFS='|' read -r src dst label hint <<< "$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
 
-    print -P "%F{34}Zsh 設定一式のセットアップが完了しました。%f"
+    msg_success "Zsh 設定一式のセットアップが完了しました。"
 }
 
 # --- アンインストール ---
@@ -93,37 +89,36 @@ uninstall_zsh() {
     local restored=0
 
     for entry in "${ZSH_MOD_MANAGED_FILES[@]}"; do
-        local dst="${entry[(ws:|:)2]}"
-        local label="${entry[(ws:|:)3]}"
+        IFS='|' read -r _src dst label _hint <<< "$entry"
 
-        # Zsh Glob 限定子で最新のバックアップを検索（シンボリックリンクも含む、ディレクトリは除外）
-        local -a latest_backup
-        latest_backup=( "${dst}.backup."*(N^/Om[1]) )
+        # find_newest_backup で最新のバックアップを検索
+        local newest
+        newest=$(find_newest_backup "${dst}.backup."'*') || true
 
-        if (( ${#latest_backup[@]} > 0 )); then
-            print -P "復元: ${label} をバックアップ (${latest_backup[1]:t}) から戻します。"
-            run_cmd command mv "${latest_backup[1]}" "$dst" || {
-                print -P "%F{160}エラー: ${label} の復元に失敗しました。%f" >&2
+        if [[ -n "$newest" ]]; then
+            printf '%s\n' "復元: ${label} をバックアップ ($(basename "$newest")) から戻します。"
+            run_cmd command mv "$newest" "$dst" || {
+                msg_error "${label} の復元に失敗しました。"
                 return 1
             }
             restored=1
         elif [[ -f "$dst" || -h "$dst" ]]; then
-            print -P "削除: ${label} を削除します（セットアップ前の状態に復元）。"
+            printf '%s\n' "削除: ${label} を削除します（セットアップ前の状態に復元）。"
             run_cmd command rm -f "$dst" || {
-                print -P "%F{160}エラー: ${label} の削除に失敗しました。%f" >&2
+                msg_error "${label} の削除に失敗しました。"
                 return 1
             }
             restored=1
         else
-            print -P "情報: ${label} は配置されていません。スキップします。"
+            msg_info "${label} は配置されていません。スキップします。"
         fi
     done
 
     if (( restored )); then
-        print -P "%F{34}Zsh 設定のアンインストールが完了しました。%f"
+        msg_success "Zsh 設定のアンインストールが完了しました。"
     else
-        print -P "情報: Zsh 設定の復元・削除対象はありませんでした。"
+        msg_info "Zsh 設定の復元・削除対象はありませんでした。"
     fi
-    print -P "NOTE: Zinit 本体は削除されていません。不要な場合は以下を手動で削除してください:"
-    print -P "  rm -rf ${ZSH_MOD_ZINIT_HOME:h}"
+    printf '%s\n' "NOTE: Zinit 本体は削除されていません。不要な場合は以下を手動で削除してください:"
+    msg_step "rm -rf $(dirname "$ZSH_MOD_ZINIT_HOME")"
 }

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -370,9 +370,6 @@ load_modules() {
     typeset -a _unsorted
 
     for module_file in "$modules_dir"/*.sh(N); do
-        # 前回ループの残留関数をクリーンアップ
-        unset 'functions[module_setup]' 'functions[module_uninstall]' 2>/dev/null
-
         # メタデータ変数をリセット
         local MODULE_ID="" MODULE_NAME="" MODULE_DESC="" MODULE_DEFAULT=0 MODULE_ORDER=50 MODULE_DEPS=""
 
@@ -388,28 +385,12 @@ load_modules() {
             continue
         fi
 
-        # module_setup / module_uninstall が定義されているか確認
-        if [[ -z "${functions[module_setup]}" ]]; then
-            print -P "%F{220}警告: ${module_file:t} に module_setup が定義されていません。スキップします。%f"
-            continue
-        fi
-
-        # functions[] で関数をリネーム（名前衝突を回避）
+        # setup_<safe_id> が定義されているか確認
         local safe_id="${MODULE_ID//-/_}"
 
-        # モジュール ID 衝突の検出（ハイフン/アンダースコア変換による衝突を含む）
-        if [[ -n "${functions[setup_${safe_id}]}" ]]; then
-            print -P "%F{160}エラー: モジュール '${MODULE_ID}' の関数名が既存モジュールと衝突しています。スキップします。%f" >&2
-            unset 'functions[module_setup]' 'functions[module_uninstall]'
+        if ! declare -f "setup_${safe_id}" >/dev/null 2>&1; then
+            print -P "%F{220}警告: ${module_file:t} に setup_${safe_id} が定義されていません。スキップします。%f"
             continue
-        fi
-
-        functions[setup_${safe_id}]=$functions[module_setup]
-        unset 'functions[module_setup]'
-
-        if [[ -n "${functions[module_uninstall]}" ]]; then
-            functions[uninstall_${safe_id}]=$functions[module_uninstall]
-            unset 'functions[module_uninstall]'
         fi
 
         # Save dependency mapping
@@ -494,7 +475,7 @@ done
 run_module_setup() {
     local module_id="$1"
     local func_name="setup_${module_id//-/_}"
-    if [[ -n "${functions[$func_name]}" ]]; then
+    if declare -f "$func_name" >/dev/null 2>&1; then
         "$func_name"
     else
         print -P "%F{160}エラー: 不明なモジュール: ${module_id}%f" >&2
@@ -503,11 +484,11 @@ run_module_setup() {
 }
 
 # モジュール ID からアンインストール関数を動的に実行
-# NOTE: module_uninstall が未定義のモジュールは正常にスキップする
+# NOTE: uninstall_<safe_id> が未定義のモジュールは正常にスキップする
 run_module_uninstall() {
     local module_id="$1"
     local func_name="uninstall_${module_id//-/_}"
-    if [[ -n "${functions[$func_name]}" ]]; then
+    if declare -f "$func_name" >/dev/null 2>&1; then
         "$func_name"
     else
         print -P "情報: ${module_id} にはアンインストール処理が定義されていません。スキップします。"

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -88,7 +88,7 @@ BACKUP_SUFFIX=".backup.$(command date +%Y%m%d%H%M%S)"
 # When DRY_RUN=1, print the command instead of executing it
 run_cmd() {
     if (( DRY_RUN )); then
-        msg_dry_run "$*"
+        msg_dry_run "$(printf '%q ' "$@")"
     else
         "$@"
     fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -1,38 +1,46 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+set -euo pipefail
 
 # ---------------------------------------------
-# 開発環境セットアップスクリプト
+# Development environment setup script
 #
-# 使用法:
-#   zsh setup.sh                  インタラクティブモード（モジュール選択）
-#   zsh setup.sh --all            全モジュール一括インストール
-#   zsh setup.sh --select zsh     特定モジュールを指定（複数可）
-#   zsh setup.sh --dry-run        変更内容のプレビューのみ
-#   zsh setup.sh --uninstall      バックアップから復元
-#   zsh setup.sh --help           ヘルプ表示
+# Usage:
+#   bash setup.sh                  Interactive mode (module selection)
+#   bash setup.sh --all            Install all modules at once
+#   bash setup.sh --select zsh     Specify modules (multiple allowed)
+#   bash setup.sh --dry-run        Preview changes only
+#   bash setup.sh --uninstall      Restore from backups
+#   bash setup.sh --help           Show help
 #
-# モジュールは modules/ ディレクトリから動的に読み込まれます。
-# 新規モジュールの追加方法は modules/ 内の既存ファイルを参照してください。
+# Modules are dynamically loaded from the modules/ directory.
+# To add new modules, refer to existing files in modules/.
 # ---------------------------------------------
 
-# --- Zsh実行確認 ---
-if [ -z "$ZSH_VERSION" ]; then
-    print -P "%F{160}エラー: このスクリプトは Zsh で実行する必要があります。%f" >&2
-    print -P "実行例: zsh $0" >&2
-    exit 1
-fi
+# --- Script directory ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Source helper libraries ---
+# shellcheck source=./lib/colors.sh
+source "${SCRIPT_DIR}/lib/colors.sh"
+# shellcheck source=./lib/array.sh
+source "${SCRIPT_DIR}/lib/array.sh"
+# shellcheck source=./lib/backup.sh
+source "${SCRIPT_DIR}/lib/backup.sh"
+# shellcheck source=./lib/tui.sh
+source "${SCRIPT_DIR}/lib/tui.sh"
+_setup_colors
 
 
 # ==============================================
-# 引数パース
+# Argument parsing
 # ==============================================
 DRY_RUN=0
 UNINSTALL=0
 ALL_FLAG=0
 HELP_FLAG=0
-typeset -a SELECT_MODULES
-typeset -A MODULE_DEPS_MAP
-typeset -A MODULE_ID_SET
+declare -a SELECT_MODULES=()
+declare -A MODULE_DEPS_MAP=()
+declare -A MODULE_ID_SET=()
 
 while (( $# > 0 )); do
     case "$1" in
@@ -47,7 +55,7 @@ while (( $# > 0 )); do
             ;;
         --select)
             if (( $# < 2 )); then
-                print -P "%F{160}エラー: --select にはモジュール名が必要です%f" >&2
+                msg_error "--select にはモジュール名が必要です"
                 exit 1
             fi
             shift
@@ -57,8 +65,8 @@ while (( $# > 0 )); do
             HELP_FLAG=1
             ;;
         *)
-            print -P "%F{160}エラー: 不明なオプション: $1%f" >&2
-            print -P "ヘルプ: zsh $0 --help" >&2
+            msg_error "不明なオプション: $1"
+            printf '  ヘルプ: bash %s --help\n' "$0" >&2
             exit 1
             ;;
     esac
@@ -67,87 +75,86 @@ done
 
 
 # ==============================================
-# 共通変数
+# Common variables
 # ==============================================
-SCRIPT_DIR="${0:a:h}"
 BACKUP_SUFFIX=".backup.$(command date +%Y%m%d%H%M%S)"
 
 
 # ==============================================
-# ヘルパー関数
+# Helper functions
 # ==============================================
 
-# dry-run 対応の実行ラッパー
-# DRY_RUN=1 の場合はコマンドを表示するだけで実行しない
+# Dry-run aware command wrapper
+# When DRY_RUN=1, print the command instead of executing it
 run_cmd() {
     if (( DRY_RUN )); then
-        print -P "%F{242}  [DRY-RUN] ${(q)@}%f"
+        msg_dry_run "$*"
     else
         "$@"
     fi
 }
 
-# 設定ファイルのバックアップと配置を行うヘルパー（べき等性対応）
-# 引数: $1=配布元パス $2=配置先パス $3=表示名 $4=未検出時の補足メッセージ
+# Config file backup and deployment helper (idempotent)
+# Args: $1=source path $2=destination path $3=display name $4=hint when missing
 install_config() {
-    local src="$1" dst="$2" label="$3" missing_hint="$4"
+    local src="$1" dst="$2" label="$3" missing_hint="${4:-}"
 
-    # 配布元が存在しない場合は警告のみ
+    # Warn if source file does not exist
     if [[ ! -f "$src" ]]; then
         if [[ -n "$missing_hint" ]]; then
-            print -P "%F{220}警告: ${label} が見つかりません。${missing_hint}%f"
+            msg_warn "${label} が見つかりません。${missing_hint}"
         else
-            print -P "%F{160}エラー: 配布元の ${label} が見つかりません: ${src}%f" >&2
+            msg_error "配布元の ${label} が見つかりません: ${src}"
             exit 1
         fi
         return 0
     fi
 
-    # べき等性チェック: シンボリックリンクでなく、内容が同一ならスキップ
+    # Idempotency check: skip if not a symlink and content is identical
     if [[ -f "$dst" && ! -h "$dst" ]] && cmp -s "$src" "$dst"; then
-        print -P "情報: ${label} は既に最新の状態です。スキップします。"
+        msg_info "${label} は既に最新の状態です。スキップします。"
         return 0
     fi
 
-    # バックアップ処理（既存ファイルまたはシンボリックリンクがある場合）
+    # Backup existing file or symlink
     if [[ -f "$dst" || -h "$dst" ]]; then
         run_cmd command mv "$dst" "${dst}${BACKUP_SUFFIX}" || {
-            print -P "%F{160}エラー: ${label} のバックアップに失敗しました。%f" >&2
+            msg_error "${label} のバックアップに失敗しました。"
             exit 1
         }
         if (( DRY_RUN )); then
-            print -P "情報: 既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップします（予定）。"
+            msg_info "既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップします（予定）。"
         else
-            print -P "情報: 既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップしました。"
+            msg_info "既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップしました。"
         fi
     fi
 
-    # 配置処理
+    # Deploy file
     run_cmd command cp -p "$src" "$dst" || {
-        print -P "%F{160}エラー: ${label} の配置に失敗しました。%f" >&2
+        msg_error "${label} の配置に失敗しました。"
         if [[ -f "${dst}${BACKUP_SUFFIX}" ]]; then
-            print -P "  バックアップは ${dst}${BACKUP_SUFFIX} に保存されています。" >&2
-            print -P "  手動で復元するには: mv '${dst}${BACKUP_SUFFIX}' '$dst'" >&2
+            printf '  バックアップは %s に保存されています。\n' "${dst}${BACKUP_SUFFIX}" >&2
+            printf '  手動で復元するには: mv '\''%s'\'' '\''%s'\''\n' "${dst}${BACKUP_SUFFIX}" "$dst" >&2
         fi
         exit 1
     }
     if (( DRY_RUN )); then
-        print -P "情報: ${label} を配置予定です（dry-run）。"
+        msg_info "${label} を配置予定です（dry-run）。"
     else
-        print -P "情報: ${label} を配置しました。"
+        msg_info "${label} を配置しました。"
     fi
 }
 
-# Node.js と npm の存在を確認するヘルパー
-# 引数: $1=最低メジャーバージョン（省略時: 18）
-# 戻り値: 0=利用可能, 1=利用不可
+# Verify Node.js and npm availability
+# Args: $1=minimum major version (default: 18)
+# Returns: 0=available, 1=unavailable
 ensure_node() {
     local min_version="${1:-18}"
 
     if ! command -v node >/dev/null 2>&1; then
-        print -P "%F{160}エラー: Node.js がインストールされていません。%f" >&2
-        print -P "  nvm, fnm, volta 等で Node.js v${min_version} 以上をインストールしてください。" >&2
-        print -P "  例: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash" >&2
+        msg_error "Node.js がインストールされていません。"
+        printf '  nvm, fnm, volta 等で Node.js v%s 以上をインストールしてください。\n' "$min_version" >&2
+        printf '  例: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash\n' >&2
         return 1
     fi
 
@@ -156,23 +163,23 @@ ensure_node() {
 
     # Validate numeric values
     if [[ ! "$min_version" =~ ^[0-9]+$ ]]; then
-        print -P "%F{160}エラー: ensure_node に不正な引数が渡されました: ${min_version}%f" >&2
+        msg_error "ensure_node に不正な引数が渡されました: ${min_version}"
         return 1
     fi
     if [[ ! "$node_ver" =~ ^[0-9]+$ ]]; then
-        print -P "%F{160}エラー: Node.js のバージョンを取得できませんでした。%f" >&2
+        msg_error "Node.js のバージョンを取得できませんでした。"
         return 1
     fi
 
     if (( node_ver < min_version )); then
-        print -P "%F{160}エラー: Node.js v${min_version} 以上が必要です（現在: v${node_ver}）%f" >&2
-        print -P "  Node.js をアップグレードしてください。" >&2
+        msg_error "Node.js v${min_version} 以上が必要です（現在: v${node_ver}）"
+        printf '  Node.js をアップグレードしてください。\n' >&2
         return 1
     fi
 
     if ! command -v npm >/dev/null 2>&1; then
-        print -P "%F{160}エラー: npm がインストールされていません。%f" >&2
-        print -P "  Node.js に付属の npm が利用可能か確認してください。" >&2
+        msg_error "npm がインストールされていません。"
+        printf '  Node.js に付属の npm が利用可能か確認してください。\n' >&2
         return 1
     fi
 
@@ -181,215 +188,54 @@ ensure_node() {
 
 
 # ==============================================
-# チェックボックス選択UI（tput ベース + 再描画方式）
+# Dynamic module loading
 # ==============================================
 
-# チェックボックスメニューを表示し、選択結果を返す
-# 引数: メニュー項目の配列（"表示名|説明|デフォルト選択(0/1)" 形式）
-# 出力: 選択されたインデックス（1始まり）をスペース区切りで REPLY 変数に設定
-# 戻り値: 0=正常終了, 1=キャンセル（q キー）
-checkbox_menu() {
-    local -a items=("$@")
-    local item_count=${#items}
-    local cursor=1
-    local -a selected
-    local -a labels
-    local -a descs
-    local redraw=0
-
-    # メニュー項目をパース
-    for i in {1..$item_count}; do
-        labels[$i]="${items[$i][(ws:|:)1]}"
-        descs[$i]="${items[$i][(ws:|:)2]}"
-        selected[$i]="${items[$i][(ws:|:)3]}"
-    done
-
-    # ヘッダー行数（操作説明 + 空行）
-    local header_lines=2
-    # 合計描画行数（ヘッダー + メニュー項目）
-    local total_lines=$(( header_lines + item_count ))
-
-    # 端末状態の保護: 異常終了時にカーソルとリセットを復帰
-    trap '_checkbox_cleanup' INT TERM QUIT
-    tput civis 2>/dev/null  # カーソル非表示
-
-    # 画面下部でのスクロールスペースを事前確保
-    for i in {1..$total_lines}; do print ""; done
-    for i in {1..$total_lines}; do tput cuu1; done
-
-    # 描画ループ
-    while true; do
-        _checkbox_draw "$item_count" "$cursor" "$header_lines" "$redraw"
-        redraw=1
-
-        # キー入力待ち
-        local key=""
-        read -k 1 key
-
-        case "$key" in
-            $'\e')
-                # ESC シーケンスの解析（矢印キー対応）
-                local key2="" key3=""
-                read -k 1 -t 0.05 key2 2>/dev/null
-                if [[ "$key2" == "[" || "$key2" == "O" ]]; then
-                    read -k 1 -t 0.05 key3 2>/dev/null
-                    case "$key3" in
-                        A) # 上矢印
-                            (( cursor > 1 )) && (( cursor-- ))
-                            ;;
-                        B) # 下矢印
-                            (( cursor < item_count )) && (( cursor++ ))
-                            ;;
-                    esac
-                fi
-                ;;
-            k) # vim: 上移動
-                (( cursor > 1 )) && (( cursor-- ))
-                ;;
-            j) # vim: 下移動
-                (( cursor < item_count )) && (( cursor++ ))
-                ;;
-            ' ') # スペース: 選択トグル
-                if (( selected[$cursor] )); then
-                    selected[$cursor]=0
-                else
-                    selected[$cursor]=1
-                fi
-                ;;
-            a) # 全選択/全解除トグル
-                local all_selected=1
-                for i in {1..$item_count}; do
-                    if (( ! selected[$i] )); then
-                        all_selected=0
-                        break
-                    fi
-                done
-                local new_val=$(( ! all_selected ))
-                for i in {1..$item_count}; do
-                    selected[$i]=$new_val
-                done
-                ;;
-            q) # キャンセル
-                tput cnorm 2>/dev/null
-                trap - INT TERM QUIT
-                return 1
-                ;;
-            $'\n') # Enter: 確定
-                break
-                ;;
-        esac
-    done
-
-    # クリーンアップ
-    tput cnorm 2>/dev/null  # カーソル表示復帰
-    trap - INT TERM QUIT
-
-    # 選択されたインデックスを REPLY 変数に設定
-    REPLY=""
-    for i in {1..$item_count}; do
-        if (( selected[$i] )); then
-            REPLY+="$i "
-        fi
-    done
-    return 0
-}
-
-# チェックボックスメニューの描画（内部関数）
-_checkbox_draw() {
-    local item_count=$1 cursor=$2 header_lines=$3 redraw=$4
-    local total_lines=$(( header_lines + item_count ))
-    local max_width=${COLUMNS:-80}
-
-    # 再描画時は描画開始位置に戻る
-    if (( redraw )); then
-        for i in {1..$total_lines}; do tput cuu1; done
-    fi
-
-    # ヘッダー
-    tput el
-    print -P "%F{36}%B インストールするモジュールを選択してください:%b%f"
-    tput el
-    print -P "%F{242} (↑↓/jk: 移動, スペース: 選択, a: 全選択, Enter: 確定, q: キャンセル)%f"
-
-    # メニュー項目
-    for i in {1..$item_count}; do
-        tput el  # 行末クリア（前回描画の残りを消す）
-
-        local prefix=" "
-        local check="[ ]"
-        local label_color=""
-        local reset=""
-
-        if (( selected[$i] )); then
-            check="[x]"
-        fi
-
-        if (( i == cursor )); then
-            # カーソル行: シアン太字
-            tput bold 2>/dev/null
-            tput setaf 6 2>/dev/null
-            prefix=">"
-        fi
-
-        # 表示文字列を組み立て、端末幅に収める
-        local line=" ${prefix} ${check} ${labels[$i]}  ${descs[$i]}"
-        if (( ${#line} > max_width )); then
-            line="${line[1,$((max_width - 1))]}"
-        fi
-        print "$line"
-
-        if (( i == cursor )); then
-            tput sgr0 2>/dev/null
-        fi
-    done
-}
-
-# チェックボックスUIの異常終了時クリーンアップ
-_checkbox_cleanup() {
-    tput cnorm 2>/dev/null  # カーソル表示復帰
-    tput sgr0 2>/dev/null   # 装飾リセット
-    print ""
-    exit 130
-}
-
-
-# ==============================================
-# モジュール動的読み込み
-# ==============================================
-
-# modules/ ディレクトリからモジュールファイルを読み込み、
-# MODULES 配列と setup_*/uninstall_* 関数を動的に構築する
+# Load module files from modules/ directory,
+# building the MODULES array and setup_*/uninstall_* functions dynamically
 load_modules() {
     local modules_dir="$SCRIPT_DIR/modules"
 
     if [[ ! -d "$modules_dir" ]]; then
-        print -P "%F{160}エラー: modules/ ディレクトリが見つかりません: ${modules_dir}%f" >&2
+        msg_error "modules/ ディレクトリが見つかりません: ${modules_dir}"
         exit 1
     fi
 
-    typeset -a _unsorted
+    declare -a _unsorted=()
+    local module_file
 
-    for module_file in "$modules_dir"/*.sh(N); do
-        # メタデータ変数をリセット
+    # NOTE: Use glob + nullglob-style check instead of zsh (N) qualifier
+    for module_file in "$modules_dir"/*.sh; do
+        # Skip if glob did not match anything (no nullglob in bash)
+        [[ -e "$module_file" ]] || continue
+
+        # Reset metadata variables
         local MODULE_ID="" MODULE_NAME="" MODULE_DESC="" MODULE_DEFAULT=0 MODULE_ORDER=50 MODULE_DEPS=""
 
-        # モジュールファイルをソース
+        # Source the module file
+        # shellcheck disable=SC1090
         if ! source "$module_file"; then
-            print -P "%F{220}警告: ${module_file:t} の読み込みに失敗しました（構文エラーの可能性）。スキップします。%f" >&2
+            local basename_file
+            basename_file="$(basename "$module_file")"
+            msg_warn "${basename_file} の読み込みに失敗しました（構文エラーの可能性）。スキップします。"
             continue
         fi
 
-        # バリデーション: 必須メタデータの確認
+        # Validation: check required metadata
         if [[ -z "$MODULE_ID" || -z "$MODULE_NAME" ]]; then
-            print -P "%F{220}警告: ${module_file:t} のメタデータが不正です。スキップします。%f"
+            local basename_file
+            basename_file="$(basename "$module_file")"
+            msg_warn "${basename_file} のメタデータが不正です。スキップします。"
             continue
         fi
 
-        # setup_<safe_id> が定義されているか確認
+        # Check that setup_<safe_id> function is defined
         local safe_id="${MODULE_ID//-/_}"
 
         if ! declare -f "setup_${safe_id}" >/dev/null 2>&1; then
-            print -P "%F{220}警告: ${module_file:t} に setup_${safe_id} が定義されていません。スキップします。%f"
+            local basename_file
+            basename_file="$(basename "$module_file")"
+            msg_warn "${basename_file} に setup_${safe_id} が定義されていません。スキップします。"
             continue
         fi
 
@@ -397,70 +243,75 @@ load_modules() {
         MODULE_DEPS_MAP[$MODULE_ID]="$MODULE_DEPS"
         MODULE_ID_SET[$MODULE_ID]=1
 
-        # ORDER 付きで一時配列に格納（後でソート）
+        # Store with ORDER prefix for sorting later
         _unsorted+=("$(printf '%03d' "$MODULE_ORDER")|${MODULE_ID}|${MODULE_NAME}|${MODULE_DESC}|${MODULE_DEFAULT}")
     done
 
-    if (( ${#_unsorted} == 0 )); then
-        print -P "%F{160}エラー: 有効なモジュールが見つかりません。%f" >&2
+    if (( ${#_unsorted[@]} == 0 )); then
+        msg_error "有効なモジュールが見つかりません。"
         exit 1
     fi
 
-    # MODULE_ORDER でソートして MODULES 配列を構築
+    # Sort by MODULE_ORDER and build MODULES array
     MODULES=()
-    for entry in ${(o)_unsorted}; do
-        # ORDER 部分（先頭の "NNN|"）を除去
+    readarray -t _sorted < <(printf '%s\n' "${_unsorted[@]}" | sort)
+    local entry
+    for entry in "${_sorted[@]}"; do
+        # Remove ORDER prefix ("NNN|")
         MODULES+=("${entry#*|}")
     done
 }
 
-# モジュールを読み込む
+# Load modules
 load_modules
 
 
 # ==============================================
-# ヘルプ表示（モジュール読み込み後に動的生成）
+# Help display (dynamically generated after module loading)
 # ==============================================
 if (( HELP_FLAG )); then
-    print -P "使用法: zsh $0 [オプション]"
-    print -P ""
-    print -P "オプション:"
-    print -P "  --dry-run          変更内容のプレビューのみ（実際には変更しない）"
-    print -P "  --uninstall        全モジュールをアンインストール（バックアップから復元）"
-    print -P "  --all              全モジュールを一括インストール"
-    print -P "  --select MODULE    特定モジュールを指定（複数指定可）"
-    print -P "  --help, -h         このヘルプを表示"
-    print -P ""
-    print -P "モジュール:"
+    printf '使用法: bash %s [オプション]\n' "$0"
+    printf '\n'
+    printf 'オプション:\n'
+    printf '  --dry-run          変更内容のプレビューのみ（実際には変更しない）\n'
+    printf '  --uninstall        全モジュールをアンインストール（バックアップから復元）\n'
+    printf '  --all              全モジュールを一括インストール\n'
+    printf '  --select MODULE    特定モジュールを指定（複数指定可）\n'
+    printf '  --help, -h         このヘルプを表示\n'
+    printf '\n'
+    printf 'モジュール:\n'
     for entry in "${MODULES[@]}"; do
-        printf "  %-14s %s (%s)\n" "${entry[(ws:|:)1]}" "${entry[(ws:|:)2]}" "${entry[(ws:|:)3]}"
+        IFS='|' read -r mod_id mod_name mod_desc _mod_default <<< "$entry"
+        printf '  %-14s %s (%s)\n' "$mod_id" "$mod_name" "$mod_desc"
     done
-    print -P ""
-    print -P "例:"
-    print -P "  zsh $0                              インタラクティブ選択"
-    print -P "  zsh $0 --all                        全モジュール一括"
-    print -P "  zsh $0 --select zsh --select claude-code  複数指定"
-    print -P "  zsh $0 --all --dry-run              全モジュールをプレビュー"
+    printf '\n'
+    printf '例:\n'
+    printf '  bash %s                              インタラクティブ選択\n' "$0"
+    printf '  bash %s --all                        全モジュール一括\n' "$0"
+    printf '  bash %s --select zsh --select claude-code  複数指定\n' "$0"
+    printf '  bash %s --all --dry-run              全モジュールをプレビュー\n' "$0"
     exit 0
 fi
 
 
 # ==============================================
-# --select バリデーション（モジュール読み込み後に検証）
+# --select validation (verified after module loading)
 # ==============================================
 for mod_id in "${SELECT_MODULES[@]}"; do
-    typeset found=0
+    local_found=0
     for entry in "${MODULES[@]}"; do
-        if [[ "${entry[(ws:|:)1]}" == "$mod_id" ]]; then
-            found=1
+        IFS='|' read -r entry_id _rest <<< "$entry"
+        if [[ "$entry_id" == "$mod_id" ]]; then
+            local_found=1
             break
         fi
     done
-    if (( ! found )); then
-        print -P "%F{160}エラー: 不明なモジュール: ${mod_id}%f" >&2
-        print -P "利用可能なモジュール:" >&2
+    if (( ! local_found )); then
+        msg_error "不明なモジュール: ${mod_id}"
+        printf '利用可能なモジュール:\n' >&2
         for entry in "${MODULES[@]}"; do
-            print -P "  ${entry[(ws:|:)1]}" >&2
+            IFS='|' read -r entry_id _rest <<< "$entry"
+            printf '  %s\n' "$entry_id" >&2
         done
         exit 1
     fi
@@ -468,81 +319,84 @@ done
 
 
 # ==============================================
-# モジュール実行ディスパッチ
+# Module execution dispatch
 # ==============================================
 
-# モジュール ID からセットアップ関数を動的に実行
+# Dynamically execute setup function for a module ID
 run_module_setup() {
     local module_id="$1"
     local func_name="setup_${module_id//-/_}"
     if declare -f "$func_name" >/dev/null 2>&1; then
         "$func_name"
     else
-        print -P "%F{160}エラー: 不明なモジュール: ${module_id}%f" >&2
+        msg_error "不明なモジュール: ${module_id}"
         return 1
     fi
 }
 
-# モジュール ID からアンインストール関数を動的に実行
-# NOTE: uninstall_<safe_id> が未定義のモジュールは正常にスキップする
+# Dynamically execute uninstall function for a module ID
+# NOTE: Modules without uninstall_<safe_id> are silently skipped
 run_module_uninstall() {
     local module_id="$1"
     local func_name="uninstall_${module_id//-/_}"
     if declare -f "$func_name" >/dev/null 2>&1; then
         "$func_name"
     else
-        print -P "情報: ${module_id} にはアンインストール処理が定義されていません。スキップします。"
+        msg_info "${module_id} にはアンインストール処理が定義されていません。スキップします。"
         return 0
     fi
 }
 
 
-# モジュール依存関係を解決し、不足している依存モジュールを自動追加する
-# 変更対象: selected_module_ids（不足する依存先を追加）
+# Resolve module dependencies and auto-add missing dependency modules
+# Modifies: selected_module_ids (adds missing dependencies)
 resolve_module_deps() {
     local -a added_deps=()
     local changed=1
 
-    # 推移的依存を解決するため、変更がなくなるまで繰り返す
+    # Iterate until no more transitive dependencies are found
     while (( changed )); do
         changed=0
         for mod_id in "${selected_module_ids[@]}"; do
-            local deps="${MODULE_DEPS_MAP[$mod_id]}"
+            local deps="${MODULE_DEPS_MAP[$mod_id]:-}"
             [[ -z "$deps" ]] && continue
 
             # MODULE_DEPS is a space-separated list
-            for dep in ${(s: :)deps}; do
+            read -ra _deps <<< "$deps"
+            local dep
+            for dep in "${_deps[@]}"; do
                 # Check if dep is already selected
-                if ! (( ${selected_module_ids[(Ie)$dep]} )); then
+                if ! array_contains "$dep" "${selected_module_ids[@]}"; then
                     # O(1) existence check
-                    if [[ -n "${MODULE_ID_SET[$dep]}" ]]; then
+                    if [[ -n "${MODULE_ID_SET[$dep]:-}" ]]; then
                         selected_module_ids+=("$dep")
                         added_deps+=("$dep")
                         changed=1
                     else
-                        print -P "%F{220}警告: モジュール '${mod_id}' の依存先 '${dep}' が見つかりません。%f" >&2
+                        msg_warn "モジュール '${mod_id}' の依存先 '${dep}' が見つかりません。"
                     fi
                 fi
             done
         done
     done
 
-    # 自動追加された依存をユーザーに通知
+    # Notify user of auto-added dependencies
     if (( ${#added_deps[@]} > 0 )); then
-        print -P ""
-        print -P "%F{36}依存関係の自動解決:%f"
+        printf '\n'
+        color_print "$C_CYAN" "依存関係の自動解決:"
         for dep in "${added_deps[@]}"; do
-            print -P "  + ${dep} (依存先として自動追加)"
+            printf '  + %s (依存先として自動追加)\n' "$dep"
         done
-        print -P ""
+        printf '\n'
     fi
 
-    # MODULE_ORDER 順に再ソート（依存先が先にインストールされるようにする）
+    # Re-sort by MODULE_ORDER so dependencies are installed first
     if (( ${#added_deps[@]} > 0 )); then
         local -a sorted_ids=()
+        local entry entry_id
         for entry in "${MODULES[@]}"; do
-            local entry_id="${entry%%|*}"
-            if (( ${selected_module_ids[(Ie)$entry_id]} )); then
+            entry_id="${entry%%|*}"
+            if array_contains "$entry_id" "${selected_module_ids[@]}"; then
                 sorted_ids+=("$entry_id")
             fi
         done
@@ -552,176 +406,182 @@ resolve_module_deps() {
 
 
 # ==============================================
-# アンインストールモード
-# NOTE: --uninstall は常に全モジュールを対象にする
+# Uninstall mode
+# NOTE: --uninstall always targets all modules
 # ==============================================
 if (( UNINSTALL )); then
-    print -P "全モジュールのアンインストール（復元）を開始します..."
-    print -P "============================================="
+    printf '%s\n' "全モジュールのアンインストール（復元）を開始します..."
+    printf '%s\n' "============================================="
 
     if (( DRY_RUN )); then
-        print -P "%F{33}[DRY-RUN モード] 実際には変更を行いません。%f"
-        print -P "---------------------------------------------"
+        color_print "${C_CYAN}" "[DRY-RUN モード] 実際には変更を行いません。"
+        print_separator
     fi
 
-    typeset -i uninstall_errors=0
+    declare -i uninstall_errors=0
 
-    # NOTE: セットアップと逆順（MODULE_ORDER 降順）でアンインストールする
-    for entry in "${(@Oa)MODULES}"; do
-        typeset mod_id="${entry[(ws:|:)1]}"
-        typeset mod_name="${entry[(ws:|:)2]}"
-        print -P ""
-        print -P "%F{36}%B[${mod_name}]%b%f"
-        print -P "---------------------------------------------"
+    # NOTE: Uninstall in reverse MODULE_ORDER (descending) order
+    readarray -t _reversed < <(printf '%s\n' "${MODULES[@]}" | tac)
+    for entry in "${_reversed[@]}"; do
+        IFS='|' read -r mod_id mod_name _rest <<< "$entry"
+        printf '\n'
+        printf '%s%s[%s]%s\n' "${C_CYAN}" "${C_BOLD}" "$mod_name" "${C_RESET}"
+        print_separator
         if ! run_module_uninstall "$mod_id"; then
-            (( uninstall_errors++ ))
+            (( uninstall_errors++ )) || true
         fi
     done
 
-    print -P ""
-    print -P "============================================="
+    printf '\n'
+    printf '%s\n' "============================================="
     if (( uninstall_errors > 0 )); then
-        print -P "%F{220}アンインストールが完了しましたが、${uninstall_errors} 件のモジュールでエラーが発生しました。%f"
-        print -P "============================================="
+        color_print "$C_YELLOW" "アンインストールが完了しましたが、${uninstall_errors} 件のモジュールでエラーが発生しました。"
+        printf '%s\n' "============================================="
         exit 1
     else
-        print -P "%F{34}アンインストールが完了しました。%f"
-        print -P "============================================="
+        msg_success "アンインストールが完了しました。"
+        printf '%s\n' "============================================="
         exit 0
     fi
 fi
 
 
 # ==============================================
-# 通常セットアップモード
+# Normal setup mode
 # ==============================================
-print -P ""
-print -P "%F{36}%B 開発環境セットアップ%b%f"
-print -P "============================================="
+printf '\n'
+printf '%s%s 開発環境セットアップ%s\n' "${C_CYAN}" "${C_BOLD}" "${C_RESET}"
+printf '%s\n' "============================================="
 
 if (( DRY_RUN )); then
-    print -P "%F{33}[DRY-RUN モード] 実際には変更を行いません。%f"
-    print -P "---------------------------------------------"
+    color_print "${C_CYAN}" "[DRY-RUN モード] 実際には変更を行いません。"
+    print_separator
 fi
 
-print -P "情報: Zsh で実行されています (バージョン: $ZSH_VERSION)"
-print -P "---------------------------------------------"
+printf '情報: Bash で実行されています (バージョン: %s)\n' "$BASH_VERSION"
+print_separator
 
-# --- モジュール選択 ---
-typeset -a selected_module_ids
+# --- Module selection ---
+declare -a selected_module_ids=()
 
 if (( ${#SELECT_MODULES[@]} > 0 )); then
-    # --select で明示指定された場合（MODULE_ORDER 順に並べ替え）
+    # Explicit --select: reorder to MODULE_ORDER
     for entry in "${MODULES[@]}"; do
-        typeset mod_id="${entry[(ws:|:)1]}"
-        if (( ${SELECT_MODULES[(I)$mod_id]} )); then
+        IFS='|' read -r mod_id _rest <<< "$entry"
+        if array_contains "$mod_id" "${SELECT_MODULES[@]}"; then
             selected_module_ids+=("$mod_id")
         fi
     done
     resolve_module_deps
 
 elif (( ALL_FLAG )); then
-    # --all の場合: 全モジュールを選択
+    # --all: select all modules
     for entry in "${MODULES[@]}"; do
-        selected_module_ids+=("${entry[(ws:|:)1]}")
+        IFS='|' read -r mod_id _rest <<< "$entry"
+        selected_module_ids+=("$mod_id")
     done
 
 elif [[ -t 0 ]]; then
-    # TTY 環境: インタラクティブ選択（チェックボックスUI）
-    print -P ""
+    # TTY environment: interactive selection (checkbox UI)
+    printf '\n'
 
     if ! command -v tput >/dev/null 2>&1; then
-        # tput が利用できない場合はデフォルト選択のモジュールのみインストール
-        print -P "%F{220}情報: tput が利用できないため、デフォルトのモジュールをインストールします。%f"
+        # tput unavailable: install only default-selected modules
+        msg_warn "tput が利用できないため、デフォルトのモジュールをインストールします。"
         for entry in "${MODULES[@]}"; do
-            if (( ${entry[(ws:|:)4]} == 1 )); then
-                selected_module_ids+=("${entry[(ws:|:)1]}")
+            IFS='|' read -r mod_id _mod_name _mod_desc mod_default <<< "$entry"
+            if (( mod_default == 1 )); then
+                selected_module_ids+=("$mod_id")
             fi
         done
     else
-        # チェックボックスメニュー用の項目を構築
-        typeset -a menu_items
+        # Build menu items for checkbox menu
+        declare -a menu_items=()
         for entry in "${MODULES[@]}"; do
-            typeset mod_name="${entry[(ws:|:)2]}"
-            typeset mod_desc="${entry[(ws:|:)3]}"
-            typeset mod_default="${entry[(ws:|:)4]}"
+            IFS='|' read -r _mod_id mod_name mod_desc mod_default <<< "$entry"
             menu_items+=("${mod_name}|${mod_desc}|${mod_default}")
         done
 
-        # チェックボックスメニュー表示
-        checkbox_menu "${menu_items[@]}"
-        typeset menu_status=$?
-        typeset selection="$REPLY"
+        # Display checkbox menu (lib/tui.sh version)
+        # NOTE: Use "|| true" to prevent set -e from exiting on cancel (return 1)
+        checkbox_menu "インストールするモジュールを選択してください:" "${menu_items[@]}" || menu_status=$?
+        menu_status="${menu_status:-0}"
+        selection="$REPLY"
 
         if (( menu_status != 0 )); then
-            print -P ""
-            print -P "%F{220}キャンセルされました。%f"
+            printf '\n'
+            msg_warn "キャンセルされました。"
             exit 0
         fi
 
         if [[ -z "$selection" ]]; then
-            print -P ""
-            print -P "%F{220}モジュールが選択されませんでした。終了します。%f"
+            printf '\n'
+            msg_warn "モジュールが選択されませんでした。終了します。"
             exit 0
         fi
 
-        # 選択されたインデックスからモジュール ID を取得
-        for idx in ${(s: :)selection}; do
-            selected_module_ids+=("${MODULES[$idx][(ws:|:)1]}")
+        # Convert 0-based selected indices to module IDs
+        read -ra _selected_indices <<< "$selection"
+        for idx in "${_selected_indices[@]}"; do
+            IFS='|' read -r mod_id _rest <<< "${MODULES[$idx]}"
+            selected_module_ids+=("$mod_id")
         done
     fi
     resolve_module_deps
 
-    print -P ""
+    printf '\n'
 else
-    # 非 TTY 環境（CI / パイプ）: --all と同等
-    print -P "情報: 非インタラクティブ環境を検出。全モジュールをインストールします。"
+    # Non-TTY environment (CI / pipe): equivalent to --all
+    msg_info "非インタラクティブ環境を検出。全モジュールをインストールします。"
     for entry in "${MODULES[@]}"; do
-        selected_module_ids+=("${entry[(ws:|:)1]}")
+        IFS='|' read -r mod_id _rest <<< "$entry"
+        selected_module_ids+=("$mod_id")
     done
 fi
 
-# 選択されたモジュールを表示
-print -P ""
-print -P "%F{36}選択されたモジュール:%f"
+# Display selected modules
+printf '\n'
+color_print "$C_CYAN" "選択されたモジュール:"
 for mod_id in "${selected_module_ids[@]}"; do
     for entry in "${MODULES[@]}"; do
-        if [[ "${entry[(ws:|:)1]}" == "$mod_id" ]]; then
-            print -P "  - ${entry[(ws:|:)2]} (${entry[(ws:|:)3]})"
+        IFS='|' read -r entry_id entry_name entry_desc _rest <<< "$entry"
+        if [[ "$entry_id" == "$mod_id" ]]; then
+            printf '  - %s (%s)\n' "$entry_name" "$entry_desc"
             break
         fi
     done
 done
-print -P "---------------------------------------------"
+print_separator
 
-# --- 選択されたモジュールを順次セットアップ ---
-typeset -i setup_errors=0
+# --- Execute selected module setups sequentially ---
+declare -i setup_errors=0
 for mod_id in "${selected_module_ids[@]}"; do
     if ! run_module_setup "$mod_id"; then
-        (( setup_errors++ ))
+        (( setup_errors++ )) || true
     fi
 done
 
-# --- 完了 ---
-print -P ""
-print -P "============================================="
+# --- Completion ---
+printf '\n'
+printf '%s\n' "============================================="
 if (( DRY_RUN )); then
-    print -P "%F{33}[DRY-RUN] 上記が実行される変更内容です。実際に適用するには --dry-run を外して再実行してください。%f"
+    color_print "${C_CYAN}" "[DRY-RUN] 上記が実行される変更内容です。実際に適用するには --dry-run を外して再実行してください。"
 elif (( setup_errors > 0 )); then
-    print -P "%F{220}セットアップが完了しましたが、${setup_errors} 件のモジュールでエラーが発生しました。%f"
+    color_print "$C_YELLOW" "セットアップが完了しましたが、${setup_errors} 件のモジュールでエラーが発生しました。"
 else
-    print -P "%F{34}セットアップが正常に完了しました。%f"
+    msg_success "セットアップが正常に完了しました。"
 
-    # Zsh が選択されていた場合のみシェル再起動を案内
+    # Show shell restart hint only if zsh module was selected
     for mod_id in "${selected_module_ids[@]}"; do
         if [[ "$mod_id" == "zsh" ]]; then
-            print -P "全ての変更を有効にするために、Zsh シェルを%B再起動%bするか '%Bexec zsh%b' を実行してください。"
-            print -P "(source ~/.zshrc は環境が汚れる場合があるため、exec zsh を推奨します)"
+            printf '全ての変更を有効にするために、シェルを%s再起動%sするか '\''%sexec zsh%s'\'' を実行してください。\n' \
+                "${C_BOLD}" "${C_BOLD_OFF}" "${C_BOLD}" "${C_BOLD_OFF}"
+            printf '(source ~/.zshrc は環境が汚れる場合があるため、exec zsh を推奨します)\n'
             break
         fi
     done
 fi
-print -P "============================================="
+printf '%s\n' "============================================="
 
 if (( setup_errors > 0 )); then
     exit 1

--- a/dotfiles/tests/test_module_metadata.bats
+++ b/dotfiles/tests/test_module_metadata.bats
@@ -44,11 +44,15 @@ MODULES_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../modules" && pwd)"
     done
 }
 
-@test "all modules define module_setup function" {
+@test "all modules define setup_<safe_id> function" {
     for f in "$MODULES_DIR"/*.sh; do
-        run grep -q '^module_setup()' "$f"
+        # Extract MODULE_ID and convert hyphens to underscores for safe_id
+        local module_id
+        module_id=$(grep '^MODULE_ID=' "$f" | head -1 | cut -d= -f2 | tr -d '"')
+        local safe_id="${module_id//-/_}"
+        run grep -q "^setup_${safe_id}()" "$f"
         if [ "$status" -ne 0 ]; then
-            echo "$(basename "$f") is missing module_setup()" >&2
+            echo "$(basename "$f") is missing setup_${safe_id}()" >&2
             return 1
         fi
     done


### PR DESCRIPTION
## 概要

setup.sh + 全10モジュールを zsh から bash に完全移行。対話シェル(zsh)とスクリプト(bash)を分離するアーキテクチャ変更の Phase 1。

Close #71

## 変更内容

### Phase 1a: 共通ヘルパーライブラリ
- `lib/colors.sh`: カラー出力ヘルパー (NO_COLOR/TTY 対応、msg_error/warn/info/success 等)
- `lib/array.sh`: 配列操作ヘルパー (array_contains, array_sort, string_split)
- `lib/backup.sh`: バックアップ検索ヘルパー (find_newest_backup)
- `lib/tui.sh`: bash 純正 TUI チェックボックスメニュー (ncurses 不要)

### Phase 1b: モジュールシステム再設計
- `module_setup()` → `setup_<module_id>()` 直接命名に変更 (全10モジュール)
- `functions[]` 動的リネームを完全撤廃
- `declare -f` による関数存在チェックに移行

### Phase 1c: TUI bash 再実装
- `read -rsn1` + ANSI エスケープによる純 bash TUI
- 矢印キーナビゲーション、スペーストグル、a/n 全選択

### Phase 1d: 全モジュール bash 変換
- `print -P "%F{N}..."` → `msg_*` ヘルパー (~309箇所)
- `${entry[(ws:|:)N]}` → `IFS='|' read -r` (~71箇所)
- `*(N^/Om[1])` → `find_newest_backup` ヘルパー
- `typeset` → `declare`

### Phase 1e: setup.sh 完全 bash 移行
- shebang: `#!/usr/bin/env bash` + `set -euo pipefail`
- `lib/` ヘルパーを source
- `${(o)}` ソート → `readarray + sort`
- `${(Ie)}` 検索 → `array_contains`
- 旧 `checkbox_menu` 削除 → `lib/tui.sh` に移行

## テスト計画

- [x] 全ファイル bash 構文チェック通過 (15/15)
- [x] BATS テスト 12/12 パス
- [ ] `bash setup.sh --all --dry-run` で動作確認
- [ ] TUI チェックボックスメニューの動作確認
- [ ] 各モジュールの個別インストール動作確認