### PR TITLE
feat: setup.sh --status でモジュールのインストール状態を一覧表示

### DIFF
--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -457,6 +457,17 @@ setup_1password() {
     msg_step "初回は 'op signin' でサインインしてください。"
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v op &>/dev/null; then
+        version=$(op --version 2>/dev/null | head -1)
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "op $version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_1password() {
     local restored=0

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -401,6 +401,17 @@ setup_claude_code() {
     msg_success "Claude Code 設定ファイルの配置が完了しました。"
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v claude &>/dev/null; then
+        version=$(claude --version 2>/dev/null | head -1 || printf '%s' "installed")
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_claude_code() {
     local restored=0

--- a/dotfiles/modules/codex-cli.sh
+++ b/dotfiles/modules/codex-cli.sh
@@ -116,6 +116,17 @@ setup_codex_cli() {
     msg_success "Codex CLI 設定ファイルの配置が完了しました。"
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v codex &>/dev/null; then
+        version=$(codex --version 2>/dev/null | head -1 || printf '%s' "installed")
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_codex_cli() {
     local restored=0

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -388,6 +388,17 @@ setup_docker() {
     fi
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v docker &>/dev/null; then
+        version=$(docker --version 2>/dev/null | head -1)
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_docker() {
     local env

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -111,6 +111,17 @@ setup_gemini_cli() {
     msg_success "Gemini CLI 設定ファイルの配置が完了しました。"
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v gemini &>/dev/null; then
+        version=$(gemini --version 2>/dev/null | head -1 || printf '%s' "installed")
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_gemini_cli() {
     local restored=0

--- a/dotfiles/modules/git.sh
+++ b/dotfiles/modules/git.sh
@@ -130,6 +130,17 @@ _git_show_user_guide() {
     fi
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v git &>/dev/null; then
+        version=$(git --version 2>/dev/null | head -1)
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_git() {
     local restored=0

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -215,12 +215,15 @@ setup_modern_cli() {
 
 # --- ステータス表示 ---
 module_status() {
-    local -a found=()
+    local -a found=() missing=()
+    local total_tools=4
 
     # eza
     if command -v eza &>/dev/null; then
         # NOTE: eza --version outputs version on line 2 (e.g. "v0.23.4 [+git]")
         found+=("eza $(eza --version 2>/dev/null | sed -n '2p' | awk '{print $1}')")
+    else
+        missing+=("eza")
     fi
 
     # bat / batcat
@@ -228,6 +231,8 @@ module_status() {
         found+=("$(bat --version 2>/dev/null | head -1)")
     elif command -v batcat &>/dev/null; then
         found+=("$(batcat --version 2>/dev/null | head -1)")
+    else
+        missing+=("bat")
     fi
 
     # fd / fdfind
@@ -235,19 +240,36 @@ module_status() {
         found+=("$(fd --version 2>/dev/null | head -1)")
     elif command -v fdfind &>/dev/null; then
         found+=("$(fdfind --version 2>/dev/null | head -1)")
+    else
+        missing+=("fd")
     fi
 
     # rg (ripgrep)
     if command -v rg &>/dev/null; then
         found+=("$(rg --version 2>/dev/null | head -1)")
+    else
+        missing+=("rg")
     fi
 
-    if ((${#found[@]} > 0)); then
+    local found_count=${#found[@]}
+
+    if ((found_count == total_tools)); then
+        # All tools installed
         local versions
         versions=$(printf '%s, ' "${found[@]}")
         versions="${versions%, }"
         printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$versions"
+    elif ((found_count > 0)); then
+        # Partial: some tools installed, some missing
+        local found_names missing_names
+        found_names=$(printf '%s, ' "${found[@]}")
+        found_names="${found_names%, }"
+        missing_names=$(printf '%s, ' "${missing[@]}")
+        missing_names="${missing_names%, }"
+        printf '  %-14s %s%-18s%s found: %s | missing: %s\n' \
+            "$MODULE_ID" "${C_YELLOW}" "△ partial" "${C_RESET}" "$found_names" "$missing_names"
     else
+        # No tools installed
         printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
     fi
 }

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -213,6 +213,45 @@ setup_modern_cli() {
     fi
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local -a found=()
+
+    # eza
+    if command -v eza &>/dev/null; then
+        # NOTE: eza --version outputs version on line 2 (e.g. "v0.23.4 [+git]")
+        found+=("eza $(eza --version 2>/dev/null | sed -n '2p' | awk '{print $1}')")
+    fi
+
+    # bat / batcat
+    if command -v bat &>/dev/null; then
+        found+=("$(bat --version 2>/dev/null | head -1)")
+    elif command -v batcat &>/dev/null; then
+        found+=("$(batcat --version 2>/dev/null | head -1)")
+    fi
+
+    # fd / fdfind
+    if command -v fd &>/dev/null; then
+        found+=("$(fd --version 2>/dev/null | head -1)")
+    elif command -v fdfind &>/dev/null; then
+        found+=("$(fdfind --version 2>/dev/null | head -1)")
+    fi
+
+    # rg (ripgrep)
+    if command -v rg &>/dev/null; then
+        found+=("$(rg --version 2>/dev/null | head -1)")
+    fi
+
+    if ((${#found[@]} > 0)); then
+        local versions
+        versions=$(printf '%s, ' "${found[@]}")
+        versions="${versions%, }"
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$versions"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 # NOTE: システムパッケージの自動削除は意図しない依存破壊のリスクがあるため、手順の表示のみとする
 uninstall_modern_cli() {

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -276,6 +276,17 @@ _node_install_config() {
     done
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v node &>/dev/null; then
+        version=$(node --version 2>/dev/null | head -1)
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "node $version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_node() {
     local restored=0

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -214,22 +214,40 @@ _py_install_config() {
 
 # --- ステータス表示 ---
 module_status() {
-    local -a found=()
+    local -a found=() missing=()
+    local total_tools=2
 
     if command -v pyenv &>/dev/null; then
         found+=("pyenv $(pyenv --version 2>/dev/null | sed 's/^pyenv //' | head -1)")
+    else
+        missing+=("pyenv")
     fi
 
     if command -v uv &>/dev/null; then
         found+=("$(uv --version 2>/dev/null | head -1)")
+    else
+        missing+=("uv")
     fi
 
-    if ((${#found[@]} > 0)); then
+    local found_count=${#found[@]}
+
+    if ((found_count == total_tools)); then
+        # Both tools installed
         local versions
         versions=$(printf '%s, ' "${found[@]}")
         versions="${versions%, }"
         printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$versions"
+    elif ((found_count > 0)); then
+        # Partial: one tool installed, one missing
+        local found_names missing_names
+        found_names=$(printf '%s, ' "${found[@]}")
+        found_names="${found_names%, }"
+        missing_names=$(printf '%s, ' "${missing[@]}")
+        missing_names="${missing_names%, }"
+        printf '  %-14s %s%-18s%s found: %s | missing: %s\n' \
+            "$MODULE_ID" "${C_YELLOW}" "△ partial" "${C_RESET}" "$found_names" "$missing_names"
     else
+        # Neither tool installed
         printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
     fi
 }

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -212,6 +212,28 @@ _py_install_config() {
     done
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local -a found=()
+
+    if command -v pyenv &>/dev/null; then
+        found+=("pyenv $(pyenv --version 2>/dev/null | sed 's/^pyenv //' | head -1)")
+    fi
+
+    if command -v uv &>/dev/null; then
+        found+=("$(uv --version 2>/dev/null | head -1)")
+    fi
+
+    if ((${#found[@]} > 0)); then
+        local versions
+        versions=$(printf '%s, ' "${found[@]}")
+        versions="${versions%, }"
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$versions"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_python() {
     local restored=0

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -108,6 +108,17 @@ setup_zsh() {
     msg_success "Zsh 設定一式のセットアップが完了しました。"
 }
 
+# --- ステータス表示 ---
+module_status() {
+    local status version
+    if command -v zsh &>/dev/null; then
+        version=$(zsh --version 2>/dev/null | head -1)
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_GREEN}" "✓ installed" "${C_RESET}" "$version"
+    else
+        printf '  %-14s %s%-18s%s %s\n' "$MODULE_ID" "${C_RED}" "✗ not found" "${C_RESET}" "-"
+    fi
+}
+
 # --- アンインストール ---
 uninstall_zsh() {
     local restored=0

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -363,30 +363,36 @@ if ((STATUS_FLAG)); then
     printf '  %-14s %-18s %s\n' "Module" "Status" "Version"
     printf '  %-14s %-18s %s\n' "──────────────" "──────────────────" "─────────────────────"
 
+    # Build ID -> file mapping once (O(n) instead of O(n^2) grep per module)
+    declare -A _status_file_map=()
+    for mod_file in "${SCRIPT_DIR}"/modules/*.sh; do
+        [[ -e "$mod_file" ]] || continue
+        _mod_id="$(
+            MODULE_ID=""
+            # shellcheck disable=SC1090
+            source "$mod_file"
+            printf '%s' "${MODULE_ID:-}"
+        )"
+        [[ -n "$_mod_id" ]] || continue
+        _status_file_map["$_mod_id"]="$mod_file"
+    done
+
     for entry in "${MODULES[@]}"; do
         IFS='|' read -r mod_id _rest <<<"$entry"
-
-        # Run module_status in a subshell to avoid variable contamination
-        # Each module file is re-sourced to get its module_status function
+        mod_file="${_status_file_map[$mod_id]-}"
+        if [[ -z "$mod_file" ]]; then
+            printf '  %-14s %-18s %s\n' "$mod_id" "? unknown" "-"
+            continue
+        fi
         (
             MODULE_ID="" MODULE_NAME="" MODULE_DESC="" MODULE_DEFAULT=0 MODULE_ORDER=50 MODULE_DEPS=""
-
-            for mod_file in "${SCRIPT_DIR}"/modules/*.sh; do
-                [[ -e "$mod_file" ]] || continue
-
-                # Peek at MODULE_ID to find the matching file
-                _peek_id=$(grep '^MODULE_ID=' "$mod_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"')
-                [[ "$_peek_id" == "$mod_id" ]] || continue
-
-                # shellcheck disable=SC1090
-                source "$mod_file"
-                if declare -f module_status >/dev/null 2>&1; then
-                    module_status
-                else
-                    printf '  %-14s %-18s %s\n' "$mod_id" "? unknown" "-"
-                fi
-                break
-            done
+            # shellcheck disable=SC1090
+            source "$mod_file"
+            if declare -f module_status >/dev/null 2>&1; then
+                module_status
+            else
+                printf '  %-14s %-18s %s\n' "$mod_id" "? unknown" "-"
+            fi
         )
     done
 

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #   bash setup.sh --dry-run        Preview changes only
 #   bash setup.sh --force          Skip diff confirmation (backup + overwrite)
 #   bash setup.sh --uninstall      Restore from backups
+#   bash setup.sh --status         Show installation status of all modules
 #   bash setup.sh --help           Show help
 #
 # Modules are dynamically loaded from the modules/ directory.
@@ -38,6 +39,7 @@ DRY_RUN=0
 UNINSTALL=0
 ALL_FLAG=0
 HELP_FLAG=0
+STATUS_FLAG=0
 FORCE=0
 declare -a SELECT_MODULES=()
 declare -A MODULE_DEPS_MAP=()
@@ -64,6 +66,9 @@ while (($# > 0)); do
         fi
         shift
         SELECT_MODULES+=("$1")
+        ;;
+    --status)
+        STATUS_FLAG=1
         ;;
     --help | -h)
         HELP_FLAG=1
@@ -351,6 +356,45 @@ load_modules() {
 load_modules
 
 # ==============================================
+# Status display (show installation status of all modules)
+# ==============================================
+if ((STATUS_FLAG)); then
+    printf '\n'
+    printf '  %-14s %-18s %s\n' "Module" "Status" "Version"
+    printf '  %-14s %-18s %s\n' "──────────────" "──────────────────" "─────────────────────"
+
+    for entry in "${MODULES[@]}"; do
+        IFS='|' read -r mod_id _rest <<<"$entry"
+
+        # Run module_status in a subshell to avoid variable contamination
+        # Each module file is re-sourced to get its module_status function
+        (
+            MODULE_ID="" MODULE_NAME="" MODULE_DESC="" MODULE_DEFAULT=0 MODULE_ORDER=50 MODULE_DEPS=""
+
+            for mod_file in "${SCRIPT_DIR}"/modules/*.sh; do
+                [[ -e "$mod_file" ]] || continue
+
+                # Peek at MODULE_ID to find the matching file
+                _peek_id=$(grep '^MODULE_ID=' "$mod_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"')
+                [[ "$_peek_id" == "$mod_id" ]] || continue
+
+                # shellcheck disable=SC1090
+                source "$mod_file"
+                if declare -f module_status >/dev/null 2>&1; then
+                    module_status
+                else
+                    printf '  %-14s %-18s %s\n' "$mod_id" "? unknown" "-"
+                fi
+                break
+            done
+        )
+    done
+
+    printf '\n'
+    exit 0
+fi
+
+# ==============================================
 # Help display (dynamically generated after module loading)
 # ==============================================
 if ((HELP_FLAG)); then
@@ -362,6 +406,7 @@ if ((HELP_FLAG)); then
     printf '  --uninstall        全モジュールをアンインストール（バックアップから復元）\n'
     printf '  --all              全モジュールを一括インストール\n'
     printf '  --select MODULE    特定モジュールを指定（複数指定可）\n'
+    printf '  --status           各モジュールのインストール状態を表示\n'
     printf '  --help, -h         このヘルプを表示\n'
     printf '\n'
     printf 'モジュール:\n'

--- a/dotfiles/tests/test_status.bats
+++ b/dotfiles/tests/test_status.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# --status option tests
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+@test "--status option is recognized and exits 0" {
+    run bash "$PROJECT_ROOT/setup.sh" --status
+    [ "$status" -eq 0 ]
+}
+
+@test "--status shows header line with Module, Status, Version" {
+    run bash "$PROJECT_ROOT/setup.sh" --status
+    [[ "$output" == *"Module"* ]]
+    [[ "$output" == *"Status"* ]]
+    [[ "$output" == *"Version"* ]]
+}
+
+@test "--status shows all module IDs" {
+    run bash "$PROJECT_ROOT/setup.sh" --status
+    [[ "$output" == *"zsh"* ]]
+    [[ "$output" == *"git"* ]]
+    [[ "$output" == *"1password"* ]]
+    [[ "$output" == *"modern-cli"* ]]
+    [[ "$output" == *"node"* ]]
+    [[ "$output" == *"docker"* ]]
+    [[ "$output" == *"claude-code"* ]]
+    [[ "$output" == *"python"* ]]
+    [[ "$output" == *"gemini-cli"* ]]
+    [[ "$output" == *"codex-cli"* ]]
+}
+
+@test "--status shows installed or not found for each module" {
+    run bash "$PROJECT_ROOT/setup.sh" --status
+    # Each module line should contain either "installed" or "not found"
+    local module_lines
+    module_lines=$(echo "$output" | grep -c -E '(installed|not found)')
+    # At least 10 modules should be listed
+    [ "$module_lines" -ge 10 ]
+}
+
+@test "all modules define module_status function" {
+    local modules_dir="$PROJECT_ROOT/modules"
+    for f in "$modules_dir"/*.sh; do
+        run grep -q 'module_status()' "$f"
+        if [ "$status" -ne 0 ]; then
+            echo "$(basename "$f") is missing module_status()" >&2
+            return 1
+        fi
+    done
+}

--- a/dotfiles/tests/test_status.bats
+++ b/dotfiles/tests/test_status.bats
@@ -32,11 +32,11 @@ setup() {
     [[ "$output" == *"codex-cli"* ]]
 }
 
-@test "--status shows installed or not found for each module" {
+@test "--status shows installed, partial, or not found for each module" {
     run bash "$PROJECT_ROOT/setup.sh" --status
-    # Each module line should contain either "installed" or "not found"
+    # Each module line should contain "installed", "partial", or "not found"
     local module_lines
-    module_lines=$(echo "$output" | grep -c -E '(installed|not found)')
+    module_lines=$(echo "$output" | grep -c -E '(installed|partial|not found)')
     # At least 10 modules should be listed
     [ "$module_lines" -ge 10 ]
 }


### PR DESCRIPTION
## Summary
- `setup.sh --status` オプションを追加し、全 10 モジュールのインストール状態とバージョンを一覧表示
- 各モジュールに `module_status()` 関数を追加（`command -v` + `--version`）
- MODULE_ORDER 順にソート、カラー出力対応

Closes #83

## Test plan
- [ ] `bash setup.sh --status` で全モジュールの状態が表示される
- [ ] 未インストールのモジュールは `✗ not found` と赤色表示
- [ ] BATS テスト 5 件が PASS
- [ ] CI (shfmt / shellcheck / BATS / dry-run) が全 PASS

🤖 Generated with [Claude Code](https://claude.ai/code)