### PR TITLE
feat: setup.sh に --upgrade オプションを追加

### DIFF
--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -128,10 +128,16 @@ _1password_install_op_apt() {
 
 # --- ヘルパー: op CLI のインストール (macOS) ---
 _1password_install_op_brew() {
-    run_cmd brew install --cask 1password-cli || {
-        msg_error "1Password CLI のインストールに失敗しました。"
-        return 1
-    }
+    if ((UPGRADE)); then
+        run_cmd brew upgrade --cask 1password-cli || {
+            msg_warn "1Password CLI のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
+    else
+        run_cmd brew install --cask 1password-cli || {
+            msg_error "1Password CLI のインストールに失敗しました。"
+            return 1
+        }
+    fi
 }
 
 # --- ヘルパー: SSH エージェント設定の案内 ---
@@ -398,7 +404,7 @@ setup_1password() {
         msg_info "op CLI は既にインストールされています ($(op --version 2>/dev/null || echo '不明'))。スキップします。"
     else
         if command -v op >/dev/null 2>&1 && ((UPGRADE)); then
-            msg_info "1password-cli のアップグレードを実行します..."
+            msg_info "1password-cli のアップグレードを実行します... (現在: $(op --version 2>/dev/null || echo 'unknown'))"
         fi
         msg_info "1Password CLI (op) をインストールします..."
         case "$env" in

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -394,9 +394,12 @@ setup_1password() {
     esac
 
     # --- 1. op CLI のインストール ---
-    if command -v op >/dev/null 2>&1; then
+    if command -v op >/dev/null 2>&1 && ! ((UPGRADE)); then
         msg_info "op CLI は既にインストールされています ($(op --version 2>/dev/null || echo '不明'))。スキップします。"
     else
+        if command -v op >/dev/null 2>&1 && ((UPGRADE)); then
+            msg_info "1password-cli のアップグレードを実行します..."
+        fi
         msg_info "1Password CLI (op) をインストールします..."
         case "$env" in
         wsl | linux)

--- a/dotfiles/modules/aws-cli.sh
+++ b/dotfiles/modules/aws-cli.sh
@@ -27,6 +27,13 @@ _aws_is_installed() {
 
     local aws_ver
     aws_ver=$(aws --version 2>/dev/null || printf '%s' "unknown")
+
+    # When UPGRADE=1, do not skip — proceed to upgrade
+    if ((UPGRADE)); then
+        msg_info "AWS CLI のアップグレードを実行します... (現在: ${aws_ver})"
+        return 1
+    fi
+
     msg_info "AWS CLI は既にインストールされています (${aws_ver})。スキップします。"
     return 0
 }
@@ -66,10 +73,16 @@ _aws_install_linux() {
     local download_url="https://awscli.amazonaws.com/awscli-exe-linux-${arch}.zip"
     msg_step "AWS CLI v2 をダウンロードします..."
 
+    # Determine install flags (--update for upgrade)
+    local install_flags=""
+    if ((UPGRADE)); then
+        install_flags="--update"
+    fi
+
     if ((DRY_RUN)); then
         msg_dry_run "curl -fsSL ${download_url} -o /tmp/awscliv2.zip"
         msg_dry_run "unzip -q -o /tmp/awscliv2.zip -d /tmp"
-        msg_dry_run "sudo /tmp/aws/install"
+        msg_dry_run "sudo /tmp/aws/install ${install_flags}"
         msg_dry_run "rm -rf /tmp/awscliv2.zip /tmp/aws"
         return 0
     fi
@@ -87,7 +100,8 @@ _aws_install_linux() {
         return 1
     }
 
-    sudo /tmp/aws/install || {
+    # shellcheck disable=SC2086
+    sudo /tmp/aws/install ${install_flags} || {
         msg_error "AWS CLI v2 のインストールに失敗しました。"
         rm -rf /tmp/awscliv2.zip /tmp/aws
         return 1
@@ -105,11 +119,18 @@ _aws_install_macos() {
         return 1
     fi
 
-    msg_step "AWS CLI v2 を Homebrew でインストールします..."
-    run_cmd brew install awscli || {
-        msg_error "AWS CLI v2 のインストールに失敗しました。"
-        return 1
-    }
+    if ((UPGRADE)); then
+        msg_step "AWS CLI v2 を Homebrew でアップグレードします..."
+        run_cmd brew upgrade awscli || {
+            msg_warn "AWS CLI v2 のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
+    else
+        msg_step "AWS CLI v2 を Homebrew でインストールします..."
+        run_cmd brew install awscli || {
+            msg_error "AWS CLI v2 のインストールに失敗しました。"
+            return 1
+        }
+    fi
 }
 
 # --- セットアップ ---

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -337,11 +337,15 @@ setup_claude_code() {
     # =========================================
 
     # べき等性チェック
-    if command -v claude >/dev/null 2>&1; then
+    if command -v claude >/dev/null 2>&1 && ! ((UPGRADE)); then
         local current_ver
         current_ver=$(claude --version 2>/dev/null || printf '%s' "unknown")
         msg_info "Claude Code は既にインストールされています (${current_ver})。スキップします。"
     else
+        # Upgrade path: show info message when upgrading an existing installation
+        if command -v claude >/dev/null 2>&1 && ((UPGRADE)); then
+            msg_info "Claude Code のアップグレードを実行します..."
+        fi
         # Node.js / npm の確認
         if ! ensure_node; then
             msg_warn "Claude Code のインストールには Node.js v18+ が必要です。"

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -344,7 +344,7 @@ setup_claude_code() {
     else
         # Upgrade path: show info message when upgrading an existing installation
         if command -v claude >/dev/null 2>&1 && ((UPGRADE)); then
-            msg_info "Claude Code のアップグレードを実行します..."
+            msg_info "Claude Code のアップグレードを実行します... (現在: $(claude --version 2>/dev/null || echo 'unknown'))"
         fi
         # Node.js / npm の確認
         if ! ensure_node; then

--- a/dotfiles/modules/codex-cli.sh
+++ b/dotfiles/modules/codex-cli.sh
@@ -49,11 +49,15 @@ setup_codex_cli() {
     # =========================================
 
     # べき等性チェック
-    if command -v codex >/dev/null 2>&1; then
+    if command -v codex >/dev/null 2>&1 && ! ((UPGRADE)); then
         local current_ver
         current_ver=$(codex --version 2>/dev/null || printf '%s' "unknown")
         msg_info "Codex CLI は既にインストールされています (${current_ver})。スキップします。"
     else
+        # Upgrade path: show info message when upgrading an existing installation
+        if command -v codex >/dev/null 2>&1 && ((UPGRADE)); then
+            msg_info "Codex CLI のアップグレードを実行します..."
+        fi
         # Node.js / npm の確認
         if ! ensure_node; then
             msg_warn "Codex CLI のインストールには Node.js v18+ が必要です。"

--- a/dotfiles/modules/codex-cli.sh
+++ b/dotfiles/modules/codex-cli.sh
@@ -56,7 +56,7 @@ setup_codex_cli() {
     else
         # Upgrade path: show info message when upgrading an existing installation
         if command -v codex >/dev/null 2>&1 && ((UPGRADE)); then
-            msg_info "Codex CLI のアップグレードを実行します..."
+            msg_info "Codex CLI のアップグレードを実行します... (現在: $(codex --version 2>/dev/null || echo 'unknown'))"
         fi
         # Node.js / npm の確認
         if ! ensure_node; then

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -304,8 +304,24 @@ setup_docker() {
 
     # --- 1. Docker のインストール（べき等） ---
     if _docker_is_installed; then
-        # インストール済み; インストールをスキップ
-        :
+        if ! ((UPGRADE)); then
+            # Already installed and not upgrading; skip installation
+            :
+        else
+            msg_info "Docker のアップグレードを実行します..."
+            case "$env" in
+            linux)
+                if ! command -v apt-get >/dev/null 2>&1; then
+                    msg_error "apt-get が見つかりません。Debian/Ubuntu 系のみ対応しています。"
+                    return 1
+                fi
+                _docker_install_apt || return 1
+                ;;
+            macos)
+                _docker_install_macos || return 1
+                ;;
+            esac
+        fi
     else
         msg_info "Docker をインストールします..."
         case "$env" in

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -45,10 +45,6 @@ _docker_is_installed() {
         return 1
     fi
 
-    local docker_ver compose_ver
-    docker_ver=$(docker --version 2>/dev/null || printf '%s' "unknown")
-    compose_ver=$(docker compose version 2>/dev/null || printf '%s' "unknown")
-    msg_info "Docker は既にインストールされています (${docker_ver}, ${compose_ver})。スキップします。"
     return 0
 }
 
@@ -313,7 +309,10 @@ setup_docker() {
     if _docker_is_installed; then
         if ! ((UPGRADE)); then
             # Already installed and not upgrading; skip installation
-            :
+            local docker_ver compose_ver
+            docker_ver=$(docker --version 2>/dev/null || printf '%s' "unknown")
+            compose_ver=$(docker compose version 2>/dev/null || printf '%s' "unknown")
+            msg_info "Docker は既にインストールされています (${docker_ver}, ${compose_ver})。スキップします。"
         else
             msg_info "Docker のアップグレードを実行します... (現在: $(docker --version 2>/dev/null || echo 'unknown'))"
             case "$env" in

--- a/dotfiles/modules/docker.sh
+++ b/dotfiles/modules/docker.sh
@@ -152,11 +152,18 @@ _docker_install_macos() {
         return 1
     fi
 
-    msg_step "Docker Desktop を Homebrew でインストールします..."
-    run_cmd brew install --cask docker || {
-        msg_error "Docker Desktop のインストールに失敗しました。"
-        return 1
-    }
+    if ((UPGRADE)); then
+        msg_step "Docker Desktop を Homebrew でアップグレードします..."
+        run_cmd brew upgrade --cask docker || {
+            msg_warn "Docker Desktop のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
+    else
+        msg_step "Docker Desktop を Homebrew でインストールします..."
+        run_cmd brew install --cask docker || {
+            msg_error "Docker Desktop のインストールに失敗しました。"
+            return 1
+        }
+    fi
 }
 
 # --- ヘルパー: Docker グループ設定 + systemd 自動起動 (Linux のみ) ---
@@ -308,7 +315,7 @@ setup_docker() {
             # Already installed and not upgrading; skip installation
             :
         else
-            msg_info "Docker のアップグレードを実行します..."
+            msg_info "Docker のアップグレードを実行します... (現在: $(docker --version 2>/dev/null || echo 'unknown'))"
             case "$env" in
             linux)
                 if ! command -v apt-get >/dev/null 2>&1; then

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -52,7 +52,7 @@ setup_gemini_cli() {
     else
         # Upgrade path: show info message when upgrading an existing installation
         if command -v gemini >/dev/null 2>&1 && ((UPGRADE)); then
-            msg_info "Gemini CLI のアップグレードを実行します..."
+            msg_info "Gemini CLI のアップグレードを実行します... (現在: $(gemini --version 2>/dev/null || echo 'unknown'))"
         fi
         # Node.js / npm の確認
         if ! ensure_node 20; then

--- a/dotfiles/modules/gemini-cli.sh
+++ b/dotfiles/modules/gemini-cli.sh
@@ -45,11 +45,15 @@ setup_gemini_cli() {
     # =========================================
 
     # べき等性チェック
-    if command -v gemini >/dev/null 2>&1; then
+    if command -v gemini >/dev/null 2>&1 && ! ((UPGRADE)); then
         local current_ver
         current_ver=$(gemini --version 2>/dev/null || printf '%s' "unknown")
         msg_info "Gemini CLI は既にインストールされています (${current_ver})。スキップします。"
     else
+        # Upgrade path: show info message when upgrading an existing installation
+        if command -v gemini >/dev/null 2>&1 && ((UPGRADE)); then
+            msg_info "Gemini CLI のアップグレードを実行します..."
+        fi
         # Node.js / npm の確認
         if ! ensure_node 20; then
             msg_warn "Gemini CLI のインストールには Node.js v20+ が必要です。"

--- a/dotfiles/modules/git.sh
+++ b/dotfiles/modules/git.sh
@@ -21,6 +21,9 @@ GIT_MOD_MANAGED_FILES=(
     "$SCRIPT_DIR/.gitignore_global|$GIT_MOD_BASE_DIR/.gitignore_global|.gitignore_global|"
 )
 
+# NOTE: No upgrade path needed -- this is a config-only module.
+# Config deployment is handled by install_config which already supports diffs.
+
 # --- セットアップ ---
 setup_git() {
     msg_header "Git グローバル設定"

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -161,7 +161,7 @@ setup_modern_cli() {
                 ((skipped++))
                 continue
             fi
-            msg_info "${cmd_name} のアップグレードを実行します..."
+            msg_info "${cmd_name} のアップグレードを実行します... (現在: $(${cmd_name} --version 2>/dev/null | head -1 || echo 'unknown'))"
         fi
         if [[ -n "$alt_cmd" ]] && command -v "$alt_cmd" >/dev/null 2>&1; then
             if ! ((UPGRADE)); then
@@ -169,18 +169,25 @@ setup_modern_cli() {
                 ((skipped++))
                 continue
             fi
-            msg_info "${cmd_name} のアップグレードを実行します..."
+            msg_info "${cmd_name} のアップグレードを実行します... (現在: $(${alt_cmd} --version 2>/dev/null | head -1 || echo 'unknown'))"
         fi
 
         printf '%s\n' "${cmd_name} をインストールします... (${desc})"
 
         case "$os" in
         macos)
-            run_cmd brew install "$brew_pkg" || {
-                msg_error "${cmd_name} のインストールに失敗しました。"
-                ((failed++))
-                continue
-            }
+            if ((UPGRADE)); then
+                run_cmd brew upgrade "$brew_pkg" || {
+                    msg_warn "${cmd_name} のアップグレードに失敗しました（既に最新の可能性があります）。"
+                    continue
+                }
+            else
+                run_cmd brew install "$brew_pkg" || {
+                    msg_error "${cmd_name} のインストールに失敗しました。"
+                    ((failed++))
+                    continue
+                }
+            fi
             ;;
         linux)
             if [[ "$cmd_name" == "eza" ]]; then

--- a/dotfiles/modules/modern-cli.sh
+++ b/dotfiles/modules/modern-cli.sh
@@ -154,16 +154,22 @@ setup_modern_cli() {
         [[ "$cmd_name" == "bat" ]] && alt_cmd="batcat"
         [[ "$cmd_name" == "fd" ]] && alt_cmd="fdfind"
 
-        # べき等性チェック
+        # Idempotency check (skip if already installed and not upgrading)
         if command -v "$cmd_name" >/dev/null 2>&1; then
-            msg_info "${cmd_name} は既にインストールされています。スキップします。"
-            ((skipped++))
-            continue
+            if ! ((UPGRADE)); then
+                msg_info "${cmd_name} は既にインストールされています。スキップします。"
+                ((skipped++))
+                continue
+            fi
+            msg_info "${cmd_name} のアップグレードを実行します..."
         fi
         if [[ -n "$alt_cmd" ]] && command -v "$alt_cmd" >/dev/null 2>&1; then
-            msg_info "${alt_cmd} (${cmd_name}) は既にインストールされています。スキップします。"
-            ((skipped++))
-            continue
+            if ! ((UPGRADE)); then
+                msg_info "${alt_cmd} (${cmd_name}) は既にインストールされています。スキップします。"
+                ((skipped++))
+                continue
+            fi
+            msg_info "${cmd_name} のアップグレードを実行します..."
         fi
 
         printf '%s\n' "${cmd_name} をインストールします... (${desc})"

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -51,8 +51,12 @@ setup_node() {
     if command -v fnm >/dev/null 2>&1; then
         local current_ver
         current_ver=$(fnm --version 2>/dev/null || printf '%s' "unknown")
-        msg_info "fnm は既にインストールされています (${current_ver})。スキップします。"
-        fnm_exists=1
+        if ((UPGRADE)); then
+            msg_info "fnm のアップグレードを実行します... (現在: ${current_ver})"
+        else
+            msg_info "fnm は既にインストールされています (${current_ver})。スキップします。"
+            fnm_exists=1
+        fi
     fi
 
     if ((!fnm_exists)); then
@@ -117,11 +121,18 @@ _node_setup_macos() {
         return 1
     fi
 
-    msg_info "fnm を Homebrew でインストールします..."
-    run_cmd brew install fnm || {
-        msg_error "fnm のインストールに失敗しました。"
-        return 1
-    }
+    if ((UPGRADE)); then
+        msg_info "fnm を Homebrew でアップグレードします..."
+        run_cmd brew upgrade fnm || {
+            msg_warn "fnm のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
+    else
+        msg_info "fnm を Homebrew でインストールします..."
+        run_cmd brew install fnm || {
+            msg_error "fnm のインストールに失敗しました。"
+            return 1
+        }
+    fi
 }
 
 # --- Linux セットアップ ---
@@ -240,7 +251,9 @@ _node_install_lts() {
             node_major="${node_major%%.*}"
         fi
 
-        if [[ "$node_major" =~ ^[0-9]+$ ]] && ((node_major >= 18)); then
+        if ((UPGRADE)); then
+            msg_info "Node.js LTS のアップグレードを実行します... (現在: ${node_ver:-unknown})"
+        elif [[ "$node_major" =~ ^[0-9]+$ ]] && ((node_major >= 18)); then
             msg_info "Node.js は既にインストールされています (${node_ver})。スキップします。"
             return 0
         elif [[ "$node_major" =~ ^[0-9]+$ ]] && ((node_major < 18)); then

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -217,10 +217,11 @@ _py_setup_uv() {
             if ((DRY_RUN)); then
                 msg_dry_run "uv self update"
             else
-                uv self update || {
+                if uv self update; then
+                    msg_success "uv をアップグレードしました。($(uv --version 2>/dev/null || echo 'version unknown'))"
+                else
                     msg_warn "uv のアップグレードに失敗しました。"
-                }
-                msg_success "uv をアップグレードしました。($(uv --version 2>/dev/null || echo 'version unknown'))"
+                fi
             fi
         else
             msg_info "uv は既にインストールされています。($(uv --version))"

--- a/dotfiles/modules/python.sh
+++ b/dotfiles/modules/python.sh
@@ -60,11 +60,15 @@ setup_python() {
     if command -v pyenv >/dev/null 2>&1; then
         local current_ver
         current_ver=$(pyenv --version 2>/dev/null || printf '%s' "unknown")
-        msg_info "pyenv は既にインストールされています (${current_ver})。スキップします。"
-        pyenv_already_installed=1
+        if ((UPGRADE)); then
+            msg_info "pyenv のアップグレードを実行します... (現在: ${current_ver})"
+        else
+            msg_info "pyenv は既にインストールされています (${current_ver})。スキップします。"
+            pyenv_already_installed=1
+        fi
     fi
 
-    # pyenv installation (skip if already installed)
+    # pyenv installation or upgrade
     if ((!pyenv_already_installed)); then
         local os
         os=$(_py_detect_os)
@@ -109,16 +113,28 @@ _py_setup_macos() {
         return 1
     fi
 
-    msg_info "pyenv を Homebrew でインストールします..."
-    run_cmd brew install pyenv || {
-        msg_error "pyenv のインストールに失敗しました。"
-        return 1
-    }
+    if ((UPGRADE)); then
+        msg_info "pyenv を Homebrew でアップグレードします..."
+        run_cmd brew upgrade pyenv || {
+            msg_warn "pyenv のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
 
-    msg_info "pyenv-virtualenv を Homebrew でインストールします..."
-    run_cmd brew install pyenv-virtualenv || {
-        msg_warn "pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。"
-    }
+        msg_info "pyenv-virtualenv を Homebrew でアップグレードします..."
+        run_cmd brew upgrade pyenv-virtualenv || {
+            msg_warn "pyenv-virtualenv のアップグレードに失敗しました（既に最新の可能性があります）。"
+        }
+    else
+        msg_info "pyenv を Homebrew でインストールします..."
+        run_cmd brew install pyenv || {
+            msg_error "pyenv のインストールに失敗しました。"
+            return 1
+        }
+
+        msg_info "pyenv-virtualenv を Homebrew でインストールします..."
+        run_cmd brew install pyenv-virtualenv || {
+            msg_warn "pyenv-virtualenv のインストールに失敗しました。pyenv 本体は利用可能です。"
+        }
+    fi
 }
 
 # --- Linux セットアップ ---
@@ -153,6 +169,20 @@ _py_setup_linux() {
                 msg_step "手動で削除してください: rm -rf $PY_MOD_PYENV_ROOT" >&2
                 return 1
             }
+        elif ((UPGRADE)); then
+            # Upgrade pyenv via git pull
+            msg_info "pyenv を git pull でアップグレードします..."
+            run_cmd git -C "$PY_MOD_PYENV_ROOT" pull || {
+                msg_warn "pyenv の git pull に失敗しました。"
+            }
+            # Also upgrade pyenv-virtualenv plugin
+            local virtualenv_dir="$PY_MOD_PYENV_ROOT/plugins/pyenv-virtualenv"
+            if [[ -d "$virtualenv_dir" ]]; then
+                msg_info "pyenv-virtualenv を git pull でアップグレードします..."
+                run_cmd git -C "$virtualenv_dir" pull || {
+                    msg_warn "pyenv-virtualenv の git pull に失敗しました。"
+                }
+            fi
         else
             msg_info "$PY_MOD_PYENV_ROOT は既に存在します。スキップします。"
         fi
@@ -182,7 +212,19 @@ _py_setup_uv() {
     msg_info "uv のセットアップを開始します..."
 
     if command -v uv &>/dev/null; then
-        msg_info "uv は既にインストールされています。($(uv --version))"
+        if ((UPGRADE)); then
+            msg_info "uv のアップグレードを実行します... (現在: $(uv --version))"
+            if ((DRY_RUN)); then
+                msg_dry_run "uv self update"
+            else
+                uv self update || {
+                    msg_warn "uv のアップグレードに失敗しました。"
+                }
+                msg_success "uv をアップグレードしました。($(uv --version 2>/dev/null || echo 'version unknown'))"
+            fi
+        else
+            msg_info "uv は既にインストールされています。($(uv --version))"
+        fi
     else
         if ((DRY_RUN)); then
             msg_dry_run "uv をインストール予定です。"

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -64,10 +64,14 @@ setup_zsh() {
             msg_success "Zinit ${ZSH_MOD_ZINIT_VERSION} のインストールに成功しました。"
         fi
     elif ((UPGRADE)); then
-        # Upgrade Zinit by pulling latest changes
+        # Upgrade Zinit in a way that works with detached HEAD / shallow clones
         msg_info "Zinit のアップグレードを実行します..."
-        run_cmd command git -C "$ZSH_MOD_ZINIT_HOME" pull || {
-            msg_error "Zinit のアップグレードに失敗しました。"
+        run_cmd command git -C "$ZSH_MOD_ZINIT_HOME" fetch --tags --force --depth 1 origin "$ZSH_MOD_ZINIT_VERSION" || {
+            msg_error "Zinit のアップグレードに失敗しました（fetch に失敗しました）。"
+            return 1
+        }
+        run_cmd command git -C "$ZSH_MOD_ZINIT_HOME" checkout --force FETCH_HEAD || {
+            msg_error "Zinit のアップグレードに失敗しました（checkout に失敗しました）。"
             return 1
         }
         if ((DRY_RUN)); then

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -63,6 +63,18 @@ setup_zsh() {
         else
             msg_success "Zinit ${ZSH_MOD_ZINIT_VERSION} のインストールに成功しました。"
         fi
+    elif ((UPGRADE)); then
+        # Upgrade Zinit by pulling latest changes
+        msg_info "Zinit のアップグレードを実行します..."
+        run_cmd command git -C "$ZSH_MOD_ZINIT_HOME" pull || {
+            msg_error "Zinit のアップグレードに失敗しました。"
+            return 1
+        }
+        if ((DRY_RUN)); then
+            msg_info "Zinit をアップグレード予定です（dry-run）。"
+        else
+            msg_success "Zinit のアップグレードが完了しました。"
+        fi
     else
         msg_info "Zinit は既にインストールされています。"
     fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   bash setup.sh --select zsh     Specify modules (multiple allowed)
 #   bash setup.sh --dry-run        Preview changes only
 #   bash setup.sh --force          Skip diff confirmation (backup + overwrite)
+#   bash setup.sh --upgrade         Upgrade installed tools to latest
 #   bash setup.sh --uninstall      Restore from backups
 #   bash setup.sh --status         Show installation status of all modules
 #   bash setup.sh --help           Show help
@@ -41,6 +42,7 @@ ALL_FLAG=0
 HELP_FLAG=0
 STATUS_FLAG=0
 FORCE=0
+UPGRADE=0
 declare -a SELECT_MODULES=()
 declare -A MODULE_DEPS_MAP=()
 declare -A MODULE_ID_SET=()
@@ -67,6 +69,9 @@ while (($# > 0)); do
         shift
         SELECT_MODULES+=("$1")
         ;;
+    --upgrade)
+        UPGRADE=1
+        ;;
     --status)
         STATUS_FLAG=1
         ;;
@@ -81,6 +86,12 @@ while (($# > 0)); do
     esac
     shift
 done
+
+# --- Mutual exclusion checks ---
+if ((UPGRADE)) && ((UNINSTALL)); then
+    msg_error "--upgrade と --uninstall は同時に指定できません"
+    exit 1
+fi
 
 # ==============================================
 # Common variables
@@ -409,6 +420,7 @@ if ((HELP_FLAG)); then
     printf 'オプション:\n'
     printf '  --dry-run          変更内容のプレビューのみ（実際には変更しない）\n'
     printf '  --force, -f        差分確認をスキップ（バックアップ＋上書き）\n'
+    printf '  --upgrade          インストール済みツールを最新バージョンに更新\n'
     printf '  --uninstall        全モジュールをアンインストール（バックアップから復元）\n'
     printf '  --all              全モジュールを一括インストール\n'
     printf '  --select MODULE    特定モジュールを指定（複数指定可）\n'

--- a/dotfiles/tests/test_upgrade.bats
+++ b/dotfiles/tests/test_upgrade.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# --upgrade option tests
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SETUP_SH="$PROJECT_ROOT/setup.sh"
+}
+
+@test "--upgrade flag exists in setup.sh argument parsing" {
+    run grep -q '\-\-upgrade)' "$SETUP_SH"
+    [ "$status" -eq 0 ]
+}
+
+@test "UPGRADE variable is initialized to 0" {
+    run grep -q 'UPGRADE=0' "$SETUP_SH"
+    [ "$status" -eq 0 ]
+}
+
+@test "--upgrade sets UPGRADE=1" {
+    run grep -q 'UPGRADE=1' "$SETUP_SH"
+    [ "$status" -eq 0 ]
+}
+
+@test "--upgrade appears in help text" {
+    run bash "$SETUP_SH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--upgrade"* ]]
+}
+
+@test "--upgrade and --uninstall are mutually exclusive" {
+    run bash "$SETUP_SH" --upgrade --uninstall
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--upgrade"* ]]
+    [[ "$output" == *"--uninstall"* ]]
+}

--- a/dotfiles/tests/test_upgrade.bats
+++ b/dotfiles/tests/test_upgrade.bats
@@ -1,26 +1,32 @@
 #!/usr/bin/env bats
 
-# --upgrade option tests
+# --upgrade option behavior tests
 
 setup() {
     PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     SETUP_SH="$PROJECT_ROOT/setup.sh"
 }
 
-@test "--upgrade flag exists in setup.sh argument parsing" {
-    run grep -q '\-\-upgrade)' "$SETUP_SH"
+# -- Behavior-based tests (replaces grep-based tests) --
+
+@test "--upgrade flag is accepted without error" {
+    run bash "$SETUP_SH" --upgrade --dry-run --all
     [ "$status" -eq 0 ]
 }
 
-@test "UPGRADE variable is initialized to 0" {
-    run grep -q 'UPGRADE=0' "$SETUP_SH"
+@test "--upgrade --dry-run --all completes successfully" {
+    run bash "$SETUP_SH" --upgrade --dry-run --all
     [ "$status" -eq 0 ]
+    [[ "$output" == *"アップグレード"* ]]
 }
 
-@test "--upgrade sets UPGRADE=1" {
-    run grep -q 'UPGRADE=1' "$SETUP_SH"
+@test "without --upgrade, no upgrade messages appear" {
+    run bash "$SETUP_SH" --dry-run --all
     [ "$status" -eq 0 ]
+    [[ "$output" != *"アップグレードを実行します"* ]]
 }
+
+# -- Help text --
 
 @test "--upgrade appears in help text" {
     run bash "$SETUP_SH" --help
@@ -28,9 +34,35 @@ setup() {
     [[ "$output" == *"--upgrade"* ]]
 }
 
+# -- Mutual exclusion --
+
 @test "--upgrade and --uninstall are mutually exclusive" {
     run bash "$SETUP_SH" --upgrade --uninstall
     [ "$status" -ne 0 ]
     [[ "$output" == *"--upgrade"* ]]
     [[ "$output" == *"--uninstall"* ]]
+}
+
+@test "--uninstall and --upgrade (reversed order) are mutually exclusive" {
+    run bash "$SETUP_SH" --uninstall --upgrade
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--upgrade"* ]]
+}
+
+# -- Selective upgrade --
+
+@test "--upgrade --select with specific module works in dry-run" {
+    run bash "$SETUP_SH" --upgrade --select git --dry-run
+    [ "$status" -eq 0 ]
+}
+
+# -- Module UPGRADE reference check --
+
+@test "all modules reference UPGRADE or document why not" {
+    for f in "$PROJECT_ROOT/modules/"*.sh; do
+        if ! grep -q -E 'UPGRADE|No upgrade path needed' "$f"; then
+            echo "$(basename "$f") does not reference UPGRADE" >&2
+            return 1
+        fi
+    done
 }


### PR DESCRIPTION
## 概要

`setup.sh` に `--upgrade` オプションを追加し、インストール済みツールのバージョン更新を可能にする。

Close #91

## 変更内容

- `setup.sh` に `UPGRADE` フラグ・引数パース・`--uninstall` との排他チェックを追加
- 全 11 モジュールの skip guard を UPGRADE 対応
- モジュール種別に応じたアップグレードパスを実装:
  - **npm 系** (claude-code, gemini-cli, codex-cli): `npm install -g` で再インストール（既にアップグレード相当）
  - **apt 系** (1password, modern-cli, docker): `apt-get install` で最新版インストール
  - **macOS brew 系**: `brew upgrade` / `brew upgrade --cask` で更新
  - **特殊パス**: aws-cli (`--update` フラグ), pyenv (`git pull`), uv (`uv self update`), Zinit (`git pull`)
- BATS テスト 5 件追加（フラグパース・排他チェック）

## 使用方法

```bash
# TUI メニューでモジュールを選択してアップグレード
bash setup.sh --upgrade

# 全モジュールを一括アップグレード
bash setup.sh --upgrade --all

# 特定モジュールを指定してアップグレード
bash setup.sh --upgrade --select python --select node

# プレビューのみ
bash setup.sh --upgrade --dry-run --all
```

## テスト計画

- [x] BATS テスト全 34 件 pass
- [x] shfmt / shellcheck pass（新規警告なし）
- [x] `--upgrade --dry-run --all` で全モジュールのアップグレードパスを確認
- [x] `--upgrade --uninstall` で排他エラーを確認