### PR TITLE
feat: 位置引数でモジュール指定 + --force の範囲拡張

### DIFF
--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -284,7 +284,12 @@ _1password_setup_service_account_token() {
         msg_step "情報: トークンファイルが既に存在します (${OP_MOD_TOKEN_FILE})。"
         printf '  上書きしますか？ [y/N]: '
         local overwrite
-        read -r overwrite
+        if ((FORCE)); then
+            overwrite="y"
+            msg_info "--force: トークンファイルを上書きします。"
+        else
+            read -r overwrite
+        fi
         if [[ "$overwrite" != [yY] ]]; then
             msg_step "スキップしました。"
             return 0
@@ -292,7 +297,12 @@ _1password_setup_service_account_token() {
     else
         printf '  サービスアカウントトークンを設定しますか？ [y/N]: '
         local configure
-        read -r configure
+        if ((FORCE)); then
+            configure="n"
+            msg_info "--force: トークン設定をスキップします。"
+        else
+            read -r configure
+        fi
         if [[ "$configure" != [yY] ]]; then
             msg_step "スキップしました。"
             return 0
@@ -510,7 +520,12 @@ uninstall_1password() {
     if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
         printf 'サービスアカウントトークンを削除しますか？ (%s) [y/N]: ' "$OP_MOD_TOKEN_FILE"
         local remove_token
-        read -r remove_token
+        if ((FORCE)); then
+            remove_token="y"
+            msg_info "--force: トークンファイルを削除します。"
+        else
+            read -r remove_token
+        fi
         if [[ "$remove_token" == [yY] ]]; then
             if ((DRY_RUN)); then
                 msg_dry_run "rm -f ${OP_MOD_TOKEN_FILE}"

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -282,12 +282,12 @@ _1password_setup_service_account_token() {
     # Check if token file already exists
     if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
         msg_step "情報: トークンファイルが既に存在します (${OP_MOD_TOKEN_FILE})。"
-        printf '  上書きしますか？ [y/N]: '
         local overwrite
         if ((FORCE)); then
-            overwrite="y"
-            msg_info "--force: トークンファイルを上書きします。"
+            overwrite="n"
+            msg_info "--force: 既存トークンファイルを維持します。"
         else
+            printf '  上書きしますか？ [y/N]: '
             read -r overwrite
         fi
         if [[ "$overwrite" != [yY] ]]; then
@@ -295,12 +295,12 @@ _1password_setup_service_account_token() {
             return 0
         fi
     else
-        printf '  サービスアカウントトークンを設定しますか？ [y/N]: '
         local configure
         if ((FORCE)); then
             configure="n"
             msg_info "--force: トークン設定をスキップします。"
         else
+            printf '  サービスアカウントトークンを設定しますか？ [y/N]: '
             read -r configure
         fi
         if [[ "$configure" != [yY] ]]; then
@@ -518,12 +518,13 @@ uninstall_1password() {
 
     # サービスアカウントトークンの削除
     if [[ -f "$OP_MOD_TOKEN_FILE" ]]; then
-        printf 'サービスアカウントトークンを削除しますか？ (%s) [y/N]: ' "$OP_MOD_TOKEN_FILE"
+        # NOTE: --force auto-accepts token deletion on uninstall (intentional per user request)
         local remove_token
         if ((FORCE)); then
             remove_token="y"
             msg_info "--force: トークンファイルを削除します。"
         else
+            printf 'サービスアカウントトークンを削除しますか？ (%s) [y/N]: ' "$OP_MOD_TOKEN_FILE"
             read -r remove_token
         fi
         if [[ "$remove_token" == [yY] ]]; then

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -81,7 +81,7 @@ while (($# > 0)); do
         ;;
     *)
         # Positional args: treat as module names if not prefixed with --
-        if [[ "$1" == --* ]]; then
+        if [[ "$1" == -* ]]; then
             msg_error "不明なオプション: $1"
             printf '  ヘルプ: bash %s --help\n' "$0" >&2
             exit 1

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 #   bash setup.sh --upgrade         Upgrade installed tools to latest
 #   bash setup.sh --uninstall      Restore from backups
 #   bash setup.sh --status         Show installation status of all modules
+#   bash setup.sh zsh git docker   Specify modules as positional args
 #   bash setup.sh --help           Show help
 #
 # Modules are dynamically loaded from the modules/ directory.
@@ -79,9 +80,13 @@ while (($# > 0)); do
         HELP_FLAG=1
         ;;
     *)
-        msg_error "不明なオプション: $1"
-        printf '  ヘルプ: bash %s --help\n' "$0" >&2
-        exit 1
+        # Positional args: treat as module names if not prefixed with --
+        if [[ "$1" == --* ]]; then
+            msg_error "不明なオプション: $1"
+            printf '  ヘルプ: bash %s --help\n' "$0" >&2
+            exit 1
+        fi
+        SELECT_MODULES+=("$1")
         ;;
     esac
     shift
@@ -415,7 +420,7 @@ fi
 # Help display (dynamically generated after module loading)
 # ==============================================
 if ((HELP_FLAG)); then
-    printf '使用法: bash %s [オプション]\n' "$0"
+    printf '使用法: bash %s [MODULE ...] [オプション]\n' "$0"
     printf '\n'
     printf 'オプション:\n'
     printf '  --dry-run          変更内容のプレビューのみ（実際には変更しない）\n'
@@ -427,6 +432,9 @@ if ((HELP_FLAG)); then
     printf '  --status           各モジュールのインストール状態を表示\n'
     printf '  --help, -h         このヘルプを表示\n'
     printf '\n'
+    printf '位置引数:\n'
+    printf '  MODULE ...         インストールするモジュールを直接指定（--select の短縮形）\n'
+    printf '\n'
     printf 'モジュール:\n'
     for entry in "${MODULES[@]}"; do
         IFS='|' read -r mod_id mod_name mod_desc _mod_default <<<"$entry"
@@ -436,7 +444,8 @@ if ((HELP_FLAG)); then
     printf '例:\n'
     printf '  bash %s                              インタラクティブ選択\n' "$0"
     printf '  bash %s --all                        全モジュール一括\n' "$0"
-    printf '  bash %s --select zsh --select claude-code  複数指定\n' "$0"
+    printf '  bash %s zsh claude-code                  位置引数で複数指定\n' "$0"
+    printf '  bash %s --select zsh --select claude-code  --select で複数指定\n' "$0"
     printf '  bash %s --all --dry-run              全モジュールをプレビュー\n' "$0"
     exit 0
 fi

--- a/dotfiles/setup.sh
+++ b/dotfiles/setup.sh
@@ -80,7 +80,7 @@ while (($# > 0)); do
         HELP_FLAG=1
         ;;
     *)
-        # Positional args: treat as module names if not prefixed with --
+        # Positional args: treat as module names if not prefixed with -
         if [[ "$1" == -* ]]; then
             msg_error "不明なオプション: $1"
             printf '  ヘルプ: bash %s --help\n' "$0" >&2
@@ -95,6 +95,11 @@ done
 # --- Mutual exclusion checks ---
 if ((UPGRADE)) && ((UNINSTALL)); then
     msg_error "--upgrade と --uninstall は同時に指定できません"
+    exit 1
+fi
+
+if ((UNINSTALL)) && ((${#SELECT_MODULES[@]} > 0)); then
+    msg_error "--uninstall はモジュール指定と併用できません（全モジュールが対象です）"
     exit 1
 fi
 

--- a/dotfiles/tests/test_positional_args.bats
+++ b/dotfiles/tests/test_positional_args.bats
@@ -46,6 +46,12 @@ setup() {
     [[ "$output" == *"不明なオプション"* ]]
 }
 
+@test "single-hyphen unknown option errors" {
+    run bash "$SETUP_SH" -x
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"不明なオプション"* ]]
+}
+
 @test "positional args appear in help text" {
     run bash "$SETUP_SH" --help
     [ "$status" -eq 0 ]

--- a/dotfiles/tests/test_positional_args.bats
+++ b/dotfiles/tests/test_positional_args.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Positional argument tests for setup.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SETUP_SH="$PROJECT_ROOT/setup.sh"
+}
+
+@test "positional arg selects module in dry-run" {
+    run bash "$SETUP_SH" git --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Git"* ]]
+}
+
+@test "multiple positional args select multiple modules" {
+    run bash "$SETUP_SH" git zsh --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Git"* ]]
+    [[ "$output" == *"Zsh"* ]]
+}
+
+@test "positional args mixed with flags work" {
+    run bash "$SETUP_SH" zsh --force --dry-run git
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Zsh"* ]]
+    [[ "$output" == *"Git"* ]]
+}
+
+@test "invalid positional arg shows error" {
+    run bash "$SETUP_SH" nonexistent --dry-run
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"不明なモジュール"* ]]
+}
+
+@test "positional args and --select can be combined" {
+    run bash "$SETUP_SH" git --select zsh --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Git"* ]]
+    [[ "$output" == *"Zsh"* ]]
+}
+
+@test "unknown --option still errors" {
+    run bash "$SETUP_SH" --nonexistent
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"不明なオプション"* ]]
+}
+
+@test "positional args appear in help text" {
+    run bash "$SETUP_SH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MODULE"* ]]
+}

--- a/dotfiles/tests/test_positional_args.bats
+++ b/dotfiles/tests/test_positional_args.bats
@@ -3,7 +3,7 @@
 # Positional argument tests for setup.sh
 
 setup() {
-    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     SETUP_SH="$PROJECT_ROOT/setup.sh"
 }
 
@@ -38,6 +38,12 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Git"* ]]
     [[ "$output" == *"Zsh"* ]]
+}
+
+@test "positional args with --uninstall errors" {
+    run bash "$SETUP_SH" docker --uninstall
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--uninstall"* ]]
 }
 
 @test "unknown --option still errors" {


### PR DESCRIPTION
## 概要

`setup.sh` に位置引数によるモジュール指定と `--force` の範囲拡張を実装。

Close #92

## 変更内容

### 位置引数対応
- `bash setup.sh zsh git docker` のように位置引数でモジュールを直接指定可能に
- `--select` との併用も可能（`bash setup.sh git --select zsh`）
- 不正なモジュール名は既存のバリデーションでエラー
- ハイフン始まりの不明オプション（`-x`, `--unknown`）は従来通りエラー

### --force 範囲拡張
- `1password.sh` の対話プロンプト 3 箇所に FORCE チェックを追加:
  - トークン上書き確認: 既存ファイル維持（スキップ）
  - トークン設定確認: スキップ（設定しない）
  - アンインストール時削除確認: 自動承諾（削除）
- `--force` 時はプロンプトメッセージ自体を非表示に

### ヘルプ更新
- 使用法に `[MODULE ...]` を追加
- 位置引数セクションと使用例を追加

## テスト計画

- [x] BATS テスト全 45 件 pass（新規 8 件）
- [x] shfmt / shellcheck pass（新規警告なし）
- [x] `bash setup.sh zsh git --dry-run` で位置引数の動作確認
- [x] 不正モジュール名のエラー確認
- [x] 単一ハイフンオプションのエラー確認