### PR TITLE
chore: 健全性チェック指摘事項を修正 (#97)

### DIFF
--- a/.claude/docs/DESIGN.md
+++ b/.claude/docs/DESIGN.md
@@ -581,8 +581,8 @@ Zsh-only config (`plugins.zsh`) remained in `dotfiles/.zsh/`.
 | Color output: semantic helpers | DRY, consistent, easy to change colors globally | Inline ANSI codes (verbose), tput setaf (slower) | 2026-03-18 |
 | Field splitting: IFS+read | Idiomatic bash, clean, one-liner per split | Helper function (verbose), cut (subshell overhead) | 2026-03-18 |
 | TUI: in-place rewrite | Preserve exact UX; read -rsn 1 is direct equivalent of read -k 1 | External tool (dialog/whiptail), simplify to numbered list | 2026-03-18 |
-| Config files: dual .zsh/.bash dirs | No breaking change for existing zsh users | Single shared dir (too many conditionals), replace .zsh entirely (breaking) | 2026-03-18 |
-| Target: bash 4+ only | declare -A required; macOS excluded from scope | bash 3.2 (no assoc arrays, much harder) | 2026-03-18 |
+| Config files: shared .shell/ dir | Unified POSIX-compatible config shared by bash and zsh | Single shared dir (too many conditionals), replace .zsh entirely (breaking) | 2026-03-18 |
+| Target: bash 4+ only | declare -A required; macOS supported via Homebrew (bash 5.x); CI runs on both Ubuntu and macOS | bash 3.2 (no assoc arrays, much harder) | 2026-03-18 |
 | Backup discovery: ls -t helper | Simple, fast, covers all cases | find -printf (GNU-only), stat (macOS incompatible -- moot since Linux-only) | 2026-03-18 |
 | Gemini role expanded to codebase analysis + research + multimodal | Gemini CLI has native 1M context; Claude Code is 200K; delegate large-context tasks to Gemini | Keep Claude for codebase analysis (requires 1M Beta) | 2026-02-19 |
 | All subagents default to Opus | 200K context makes quality of reasoning more important than context size; Opus provides better output | Sonnet (cheaper but 200K same as Opus, weaker reasoning) | 2026-02-19 |

--- a/.claude/docs/DESIGN.md
+++ b/.claude/docs/DESIGN.md
@@ -583,7 +583,7 @@ Zsh-only config (`plugins.zsh`) remained in `dotfiles/.zsh/`.
 | TUI: in-place rewrite | Preserve exact UX; read -rsn 1 is direct equivalent of read -k 1 | External tool (dialog/whiptail), simplify to numbered list | 2026-03-18 |
 | Config files: shared .shell/ dir | Unified POSIX-compatible config shared by bash and zsh | Single shared dir (too many conditionals), replace .zsh entirely (breaking) | 2026-03-18 |
 | Target: bash 4+ only | declare -A required; macOS supported via Homebrew (bash 5.x); CI runs on both Ubuntu and macOS | bash 3.2 (no assoc arrays, much harder) | 2026-03-18 |
-| Backup discovery: ls -t helper | Simple, fast, covers all cases | find -printf (GNU-only), stat (macOS incompatible -- moot since Linux-only) | 2026-03-18 |
+| Backup discovery: ls -t helper | Simple, fast, covers all cases | find -printf (GNU-only, not portable to macOS/BSD), stat (flags differ between GNU/BSD; not reliably portable) | 2026-03-18 |
 | Gemini role expanded to codebase analysis + research + multimodal | Gemini CLI has native 1M context; Claude Code is 200K; delegate large-context tasks to Gemini | Keep Claude for codebase analysis (requires 1M Beta) | 2026-02-19 |
 | All subagents default to Opus | 200K context makes quality of reasoning more important than context size; Opus provides better output | Sonnet (cheaper but 200K same as Opus, weaker reasoning) | 2026-02-19 |
 | Agent Teams default model changed to Opus | Consistent with subagent model selection; better reasoning for parallel tasks | Sonnet (cheaper) | 2026-02-19 |

--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ dev-templates/
 │   │   ├── codex-cli.sh      # モジュール: Codex CLI
 │   │   ├── python.sh         # モジュール: Python 開発環境
 │   │   └── gemini-cli.sh     # モジュール: Gemini CLI
+│   ├── tests/
+│   │   ├── test_backup_sort.bats      # テスト: バックアップソート
+│   │   ├── test_detect_env.bats       # テスト: 環境検出
+│   │   ├── test_flag_behavior.bats    # テスト: フラグ動作
+│   │   ├── test_install_config.bats   # テスト: インストール設定
+│   │   ├── test_module_metadata.bats  # テスト: モジュールメタデータ
+│   │   ├── test_positional_args.bats  # テスト: 位置引数
+│   │   ├── test_status.bats           # テスト: ステータス表示
+│   │   └── test_upgrade.bats          # テスト: アップグレード
 │   ├── .gitconfig.shared     # Git 共有設定（include.path 経由）
 │   ├── .gitignore_global     # グローバル gitignore
 │   ├── .bashrc                # Bash エントリーポイント（.shell/ 読み込み）

--- a/README.md
+++ b/README.md
@@ -335,12 +335,15 @@ dev-templates/
 │   │   ├── python.sh         # モジュール: Python 開発環境
 │   │   └── gemini-cli.sh     # モジュール: Gemini CLI
 │   ├── tests/
+│   │   ├── helpers/
+│   │   │   └── setup_functions.bash   # テストヘルパー: 共通セットアップ関数
 │   │   ├── test_backup_sort.bats      # テスト: バックアップソート
 │   │   ├── test_detect_env.bats       # テスト: 環境検出
 │   │   ├── test_flag_behavior.bats    # テスト: フラグ動作
 │   │   ├── test_install_config.bats   # テスト: インストール設定
 │   │   ├── test_module_metadata.bats  # テスト: モジュールメタデータ
 │   │   ├── test_positional_args.bats  # テスト: 位置引数
+│   │   ├── test_setup_functions.bats  # テスト: セットアップ関数
 │   │   ├── test_status.bats           # テスト: ステータス表示
 │   │   └── test_upgrade.bats          # テスト: アップグレード
 │   ├── .gitconfig.shared     # Git 共有設定（include.path 経由）

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -9,6 +9,7 @@ MODULE_NAME="Claude Code"
 MODULE_DESC="Anthropic CLI + 設定ファイル (Node.js v18+ 必要)"
 MODULE_DEFAULT=0
 MODULE_ORDER=20
+MODULE_DEPS="node"
 
 # --- Claude Code 固有変数 ---
 # NOTE: モジュール固有の変数には衝突回避のため CLAUDE_MOD_ プレフィックスを使用

--- a/dotfiles/tests/helpers/setup_functions.bash
+++ b/dotfiles/tests/helpers/setup_functions.bash
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Shared test helper functions extracted from setup.sh
+#
+# NOTE: We cannot source setup.sh directly because it runs load_modules
+# and other side effects. Instead, the key functions are defined here
+# as simplified versions for testing.
+#
+# NOTE: install_config below is a simplified version of setup.sh (lines ~117-213)
+# for testing. The interactive diff prompt ([y/N/d]) and cp failure recovery
+# hints are omitted.
+# If the production install_config changes, review and update this test version
+# accordingly.
+
+# Source this file in BATS setup() after sourcing lib/*.sh and setting flags.
+# Required variables: DOTFILES_DIR, DRY_RUN, FORCE, BACKUP_SUFFIX
+
+# run_cmd: dry-run aware command wrapper
+run_cmd() {
+    if ((DRY_RUN)); then
+        msg_dry_run "$(printf '%q ' "$@")"
+    else
+        "$@"
+    fi
+}
+
+# install_config: config file backup and deployment helper
+install_config() {
+    local src="$1" dst="$2" label="$3" missing_hint="${4:-}"
+
+    if [[ ! -f "$src" ]]; then
+        if [[ -n "$missing_hint" ]]; then
+            msg_warn "${label} が見つかりません。${missing_hint}"
+        else
+            msg_error "配布元の ${label} が見つかりません: ${src}"
+            exit 1
+        fi
+        return 0
+    fi
+
+    if [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"; then
+        msg_info "${label} は既に最新の状態です。スキップします。"
+        return 0
+    fi
+
+    if [[ -f "$dst" || -L "$dst" ]]; then
+        if ((DRY_RUN)); then
+            msg_dry_run "${label} を更新予定です。"
+            return 0
+        fi
+
+        if ! ((FORCE)); then
+            # In test context, interactive prompt is not reachable.
+            # Tests that hit this path would hang, so we only test
+            # FORCE mode and DRY_RUN mode for the "differs" scenario.
+            msg_info "スキップしました: ${label}"
+            return 0
+        fi
+
+        run_cmd command mv "$dst" "${dst}${BACKUP_SUFFIX}" || {
+            msg_error "${label} のバックアップに失敗しました。"
+            exit 1
+        }
+        msg_info "既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップしました。"
+    fi
+
+    run_cmd command cp -p "$src" "$dst" || {
+        msg_error "${label} の配置に失敗しました。"
+        exit 1
+    }
+    msg_info "${label} を配置しました。"
+}
+
+# install_source_config: deploy config via source separation
+install_source_config() {
+    local src="$1"
+    local user_file="$2"
+    local deploy_dir="$3"
+    local deploy_name="$4"
+    local label="$5"
+
+    if [[ ! -d "$deploy_dir" ]]; then
+        run_cmd command mkdir -p -m 700 "$deploy_dir" || {
+            msg_error "${deploy_dir} の作成に失敗しました。"
+            return 1
+        }
+    fi
+    install_config "$src" "${deploy_dir}/${deploy_name}" "$label"
+
+    local source_line="source \"${deploy_dir}/${deploy_name}\""
+
+    if [[ -f "$user_file" ]] && grep -qF "$source_line" "$user_file" 2>/dev/null; then
+        msg_info "${label}: source 行は $(basename "$user_file") に設定済みです。"
+        return 0
+    fi
+
+    if ((DRY_RUN)); then
+        msg_dry_run "$(basename "$user_file") に source 行を追加予定です。"
+        return 0
+    fi
+
+    {
+        printf '\n'
+        printf '# dev-templates managed - do not remove\n'
+        printf '%s\n' "$source_line"
+    } >>"$user_file"
+    msg_success "$(basename "$user_file") に source 行を追加しました。"
+}

--- a/dotfiles/tests/test_backup_sort.bats
+++ b/dotfiles/tests/test_backup_sort.bats
@@ -1,25 +1,85 @@
 #!/usr/bin/env bats
 
-# Backup restore sort order tests (regression for #59)
+# Tests for find_newest_backup() in lib/backup.sh
 
-MODULES_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../modules" && pwd)"
-
-@test "no modules use om[1] (oldest-first) for backup restore" {
-    for f in "$MODULES_DIR"/*.sh; do
-        run grep -n 'om\[1\]' "$f"
-        if [ "$status" -eq 0 ]; then
-            echo "$(basename "$f") uses om[1] (oldest-first) instead of Om[1] (newest-first): $output" >&2
-            return 1
-        fi
-    done
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/backup.sh
+    source "$PROJECT_ROOT/lib/backup.sh"
+    TEST_TMPDIR="$(mktemp -d)"
 }
 
-@test "modules using backup restore use Om[1] (newest-first)" {
-    local found=0
-    for f in "$MODULES_DIR"/*.sh; do
-        if grep -q 'Om\[1\]' "$f"; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ] || skip "No modules use backup restore pattern"
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# ============================================================
+# find_newest_backup() tests
+# ============================================================
+
+@test "find_newest_backup returns newest backup by modification time" {
+    # Arrange: create backup files with different modification times
+    touch "$TEST_TMPDIR/config.bak.20260101000000"
+    touch "$TEST_TMPDIR/config.bak.20260301000000"
+    touch "$TEST_TMPDIR/config.bak.20260201000000"
+    # Ensure modification-time order matches name order
+    touch -t 202601010000 "$TEST_TMPDIR/config.bak.20260101000000"
+    touch -t 202603010000 "$TEST_TMPDIR/config.bak.20260301000000"
+    touch -t 202602010000 "$TEST_TMPDIR/config.bak.20260201000000"
+
+    # Act
+    run find_newest_backup "$TEST_TMPDIR/config.bak.*"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"20260301000000"* ]]
+}
+
+@test "find_newest_backup returns 1 when no backups exist" {
+    # Act
+    run find_newest_backup "$TEST_TMPDIR/nonexistent.bak.*"
+
+    # Assert
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "find_newest_backup handles single backup file" {
+    # Arrange
+    touch "$TEST_TMPDIR/config.bak.20260115120000"
+
+    # Act
+    run find_newest_backup "$TEST_TMPDIR/config.bak.*"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"20260115120000"* ]]
+}
+
+@test "find_newest_backup returns full path" {
+    # Arrange
+    touch "$TEST_TMPDIR/myfile.bak.20260501000000"
+
+    # Act
+    run find_newest_backup "$TEST_TMPDIR/myfile.bak.*"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TEST_TMPDIR/myfile.bak.20260501000000" ]
+}
+
+@test "find_newest_backup picks newest by mtime not by name" {
+    # Arrange: name order differs from modification-time order
+    touch "$TEST_TMPDIR/rc.bak.AAA"
+    touch "$TEST_TMPDIR/rc.bak.ZZZ"
+    # Make AAA newer by mtime even though ZZZ sorts later alphabetically
+    touch -t 202601010000 "$TEST_TMPDIR/rc.bak.ZZZ"
+    touch -t 202612010000 "$TEST_TMPDIR/rc.bak.AAA"
+
+    # Act
+    run find_newest_backup "$TEST_TMPDIR/rc.bak.*"
+
+    # Assert: AAA is picked (newest mtime)
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rc.bak.AAA" ]]
 }

--- a/dotfiles/tests/test_flag_behavior.bats
+++ b/dotfiles/tests/test_flag_behavior.bats
@@ -27,74 +27,13 @@ setup() {
     FORCE=0
     BACKUP_SUFFIX=".backup.test"
 
-    # Source helper functions from setup.sh by extracting them
-    # NOTE: We cannot source setup.sh directly because it runs load_modules
-    # and other side effects. Instead, define the functions inline from setup.sh.
-    _source_setup_functions
+    # Source shared helper functions (run_cmd, install_config, install_source_config)
+    # shellcheck source=helpers/setup_functions.bash
+    source "$BATS_TEST_DIRNAME/helpers/setup_functions.bash"
 }
 
 teardown() {
     rm -rf "$TEST_TMPDIR"
-}
-
-# Extract install_config from setup.sh without triggering side effects.
-# Mirrors the approach in test_install_config.bats.
-# NOTE: install_config below is a simplified version of setup.sh (lines ~117-213) for testing.
-# The interactive diff prompt ([y/N/d]) and cp failure recovery hints are omitted.
-# If the production install_config changes, review and update this test version accordingly.
-_source_setup_functions() {
-    # run_cmd: dry-run aware command wrapper
-    run_cmd() {
-        if ((DRY_RUN)); then
-            msg_dry_run "$(printf '%q ' "$@")"
-        else
-            "$@"
-        fi
-    }
-
-    # install_config: config file backup and deployment helper
-    install_config() {
-        local src="$1" dst="$2" label="$3" missing_hint="${4:-}"
-
-        if [[ ! -f "$src" ]]; then
-            if [[ -n "$missing_hint" ]]; then
-                msg_warn "${label} が見つかりません。${missing_hint}"
-            else
-                msg_error "配布元の ${label} が見つかりません: ${src}"
-                exit 1
-            fi
-            return 0
-        fi
-
-        if [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"; then
-            msg_info "${label} は既に最新の状態です。スキップします。"
-            return 0
-        fi
-
-        if [[ -f "$dst" || -L "$dst" ]]; then
-            if ((DRY_RUN)); then
-                msg_dry_run "${label} を更新予定です。"
-                return 0
-            fi
-
-            if ! ((FORCE)); then
-                msg_info "スキップしました: ${label}"
-                return 0
-            fi
-
-            run_cmd command mv "$dst" "${dst}${BACKUP_SUFFIX}" || {
-                msg_error "${label} のバックアップに失敗しました。"
-                exit 1
-            }
-            msg_info "既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップしました。"
-        fi
-
-        run_cmd command cp -p "$src" "$dst" || {
-            msg_error "${label} の配置に失敗しました。"
-            exit 1
-        }
-        msg_info "${label} を配置しました。"
-    }
 }
 
 # ============================================================

--- a/dotfiles/tests/test_install_config.bats
+++ b/dotfiles/tests/test_install_config.bats
@@ -26,113 +26,13 @@ setup() {
     FORCE=0
     BACKUP_SUFFIX=".backup.test"
 
-    # Source helper functions from setup.sh by extracting them
-    # NOTE: We cannot source setup.sh directly because it runs load_modules
-    # and other side effects. Instead, define the functions inline from setup.sh.
-    _source_setup_functions
+    # Source shared helper functions (run_cmd, install_config, install_source_config)
+    # shellcheck source=helpers/setup_functions.bash
+    source "$BATS_TEST_DIRNAME/helpers/setup_functions.bash"
 }
 
 teardown() {
     rm -rf "$TEST_TMPDIR"
-}
-
-# Extract install_config and install_source_config from setup.sh
-# without triggering side effects (module loading, arg parsing, etc.)
-# NOTE: install_config below is a simplified version of setup.sh (lines ~117-213) for testing.
-# The interactive diff prompt ([y/N/d]) and cp failure recovery hints are omitted.
-# If the production install_config changes, review and update this test version accordingly.
-_source_setup_functions() {
-    # run_cmd: dry-run aware command wrapper
-    run_cmd() {
-        if ((DRY_RUN)); then
-            msg_dry_run "$(printf '%q ' "$@")"
-        else
-            "$@"
-        fi
-    }
-
-    # install_config: config file backup and deployment helper
-    install_config() {
-        local src="$1" dst="$2" label="$3" missing_hint="${4:-}"
-
-        if [[ ! -f "$src" ]]; then
-            if [[ -n "$missing_hint" ]]; then
-                msg_warn "${label} が見つかりません。${missing_hint}"
-            else
-                msg_error "配布元の ${label} が見つかりません: ${src}"
-                exit 1
-            fi
-            return 0
-        fi
-
-        if [[ -f "$dst" && ! -L "$dst" ]] && cmp -s "$src" "$dst"; then
-            msg_info "${label} は既に最新の状態です。スキップします。"
-            return 0
-        fi
-
-        if [[ -f "$dst" || -L "$dst" ]]; then
-            if ((DRY_RUN)); then
-                msg_dry_run "${label} を更新予定です。"
-                return 0
-            fi
-
-            if ! ((FORCE)); then
-                # In test context, interactive prompt is not reachable.
-                # Tests that hit this path would hang, so we only test
-                # FORCE mode and DRY_RUN mode for the "differs" scenario.
-                msg_info "スキップしました: ${label}"
-                return 0
-            fi
-
-            run_cmd command mv "$dst" "${dst}${BACKUP_SUFFIX}" || {
-                msg_error "${label} のバックアップに失敗しました。"
-                exit 1
-            }
-            msg_info "既存の ${label} を ${dst}${BACKUP_SUFFIX} にバックアップしました。"
-        fi
-
-        run_cmd command cp -p "$src" "$dst" || {
-            msg_error "${label} の配置に失敗しました。"
-            exit 1
-        }
-        msg_info "${label} を配置しました。"
-    }
-
-    # install_source_config: deploy config via source separation
-    install_source_config() {
-        local src="$1"
-        local user_file="$2"
-        local deploy_dir="$3"
-        local deploy_name="$4"
-        local label="$5"
-
-        if [[ ! -d "$deploy_dir" ]]; then
-            run_cmd command mkdir -p -m 700 "$deploy_dir" || {
-                msg_error "${deploy_dir} の作成に失敗しました。"
-                return 1
-            }
-        fi
-        install_config "$src" "${deploy_dir}/${deploy_name}" "$label"
-
-        local source_line="source \"${deploy_dir}/${deploy_name}\""
-
-        if [[ -f "$user_file" ]] && grep -qF "$source_line" "$user_file" 2>/dev/null; then
-            msg_info "${label}: source 行は $(basename "$user_file") に設定済みです。"
-            return 0
-        fi
-
-        if ((DRY_RUN)); then
-            msg_dry_run "$(basename "$user_file") に source 行を追加予定です。"
-            return 0
-        fi
-
-        {
-            printf '\n'
-            printf '# dev-templates managed - do not remove\n'
-            printf '%s\n' "$source_line"
-        } >>"$user_file"
-        msg_success "$(basename "$user_file") に source 行を追加しました。"
-    }
 }
 
 # ============================================================

--- a/dotfiles/tests/test_setup_functions.bats
+++ b/dotfiles/tests/test_setup_functions.bats
@@ -1,0 +1,352 @@
+#!/usr/bin/env bats
+
+# Tests for ensure_node() and resolve_module_deps() from setup.sh
+# These functions are extracted inline to avoid setup.sh side effects.
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/colors.sh
+    source "$PROJECT_ROOT/lib/colors.sh"
+    # shellcheck source=../lib/array.sh
+    source "$PROJECT_ROOT/lib/array.sh"
+    _setup_colors
+
+    _define_ensure_node
+    _define_resolve_module_deps
+}
+
+# Extract ensure_node from setup.sh without triggering side effects.
+# NOTE: This is a verbatim copy of setup.sh ensure_node (lines ~263-298).
+# If the production ensure_node changes, review and update this test version.
+_define_ensure_node() {
+    ensure_node() {
+        local min_version="${1:-18}"
+
+        if ! command -v node >/dev/null 2>&1; then
+            msg_error "Node.js がインストールされていません。"
+            printf '  nvm, fnm, volta 等で Node.js v%s 以上をインストールしてください。\n' "$min_version" >&2
+            printf '  例: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash\n' >&2
+            return 1
+        fi
+
+        local node_ver
+        node_ver=$(node -v | sed 's/^v//' | cut -d. -f1)
+
+        # Validate numeric values
+        if [[ ! "$min_version" =~ ^[0-9]+$ ]]; then
+            msg_error "ensure_node に不正な引数が渡されました: ${min_version}"
+            return 1
+        fi
+        if [[ ! "$node_ver" =~ ^[0-9]+$ ]]; then
+            msg_error "Node.js のバージョンを取得できませんでした。"
+            return 1
+        fi
+
+        if ((node_ver < min_version)); then
+            msg_error "Node.js v${min_version} 以上が必要です（現在: v${node_ver}）"
+            printf '  Node.js をアップグレードしてください。\n' >&2
+            return 1
+        fi
+
+        if ! command -v npm >/dev/null 2>&1; then
+            msg_error "npm がインストールされていません。"
+            printf '  Node.js に付属の npm が利用可能か確認してください。\n' >&2
+            return 1
+        fi
+
+        return 0
+    }
+}
+
+# Extract resolve_module_deps from setup.sh without triggering side effects.
+# NOTE: This is a verbatim copy of setup.sh resolve_module_deps (lines ~512-563).
+# If the production resolve_module_deps changes, review and update this test version.
+_define_resolve_module_deps() {
+    resolve_module_deps() {
+        local -a added_deps=()
+        local changed=1
+
+        # Iterate until no more transitive dependencies are found
+        while ((changed)); do
+            changed=0
+            for mod_id in "${selected_module_ids[@]}"; do
+                local deps="${MODULE_DEPS_MAP[$mod_id]:-}"
+                [[ -z "$deps" ]] && continue
+
+                # MODULE_DEPS is a space-separated list
+                read -ra _deps <<<"$deps"
+                local dep
+                for dep in "${_deps[@]}"; do
+                    # Check if dep is already selected
+                    if ! array_contains "$dep" "${selected_module_ids[@]}"; then
+                        # O(1) existence check
+                        if [[ -n "${MODULE_ID_SET[$dep]:-}" ]]; then
+                            selected_module_ids+=("$dep")
+                            added_deps+=("$dep")
+                            changed=1
+                        else
+                            msg_warn "モジュール '${mod_id}' の依存先 '${dep}' が見つかりません。"
+                        fi
+                    fi
+                done
+            done
+        done
+
+        # Notify user of auto-added dependencies
+        if ((${#added_deps[@]} > 0)); then
+            printf '\n'
+            color_print "$C_CYAN" "依存関係の自動解決:"
+            for dep in "${added_deps[@]}"; do
+                printf '  + %s (依存先として自動追加)\n' "$dep"
+            done
+            printf '\n'
+        fi
+
+        # Re-sort by MODULE_ORDER so dependencies are installed first
+        if ((${#added_deps[@]} > 0)); then
+            local -a sorted_ids=()
+            local entry entry_id
+            for entry in "${MODULES[@]}"; do
+                entry_id="${entry%%|*}"
+                if array_contains "$entry_id" "${selected_module_ids[@]}"; then
+                    sorted_ids+=("$entry_id")
+                fi
+            done
+            selected_module_ids=("${sorted_ids[@]}")
+        fi
+    }
+}
+
+# ============================================================
+# ensure_node tests
+# ============================================================
+
+@test "ensure_node succeeds when node and npm are available" {
+    # Skip if node or npm is not installed in the test environment
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+    command -v npm >/dev/null 2>&1 || skip "npm not installed"
+
+    run ensure_node
+    [ "$status" -eq 0 ]
+}
+
+@test "ensure_node succeeds with explicit version below current" {
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+    command -v npm >/dev/null 2>&1 || skip "npm not installed"
+
+    # Require version 1 -- any installed node should satisfy this
+    run ensure_node 1
+    [ "$status" -eq 0 ]
+}
+
+@test "ensure_node fails when minimum version exceeds current" {
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+
+    # Require version 999 -- no real node should satisfy this
+    run ensure_node 999
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v999 以上が必要です"* ]]
+}
+
+@test "ensure_node rejects non-numeric min_version argument" {
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+
+    run ensure_node "abc"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"不正な引数"* ]]
+}
+
+@test "ensure_node fails when node is not found" {
+    # Stub node as a function that always fails
+    node() { return 127; }
+    export -f node
+    # Override command -v to report node as missing
+    command() {
+        if [[ "$1" == "-v" && "$2" == "node" ]]; then
+            return 1
+        fi
+        builtin command "$@"
+    }
+
+    run ensure_node
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Node.js がインストールされていません"* ]]
+}
+
+@test "ensure_node fails when npm is not found" {
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+
+    # Create a temporary directory with a fake node but no npm
+    local fake_bin
+    fake_bin="$(mktemp -d)"
+    local real_node real_sed real_cut
+    real_node="$(command -v node)"
+    real_sed="$(command -v sed)"
+    real_cut="$(command -v cut)"
+    ln -s "$real_node" "${fake_bin}/node"
+    ln -s "$real_sed" "${fake_bin}/sed"
+    ln -s "$real_cut" "${fake_bin}/cut"
+    # Do NOT link npm
+
+    local saved_path="$PATH"
+    PATH="$fake_bin"
+    run ensure_node
+    PATH="$saved_path"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"npm がインストールされていません"* ]]
+
+    rm -rf "$fake_bin"
+}
+
+# ============================================================
+# resolve_module_deps tests
+# ============================================================
+
+# Helper: set up module registry for dependency tests.
+# MODULES entries use the production format: "id|name|desc|default"
+# (ORDER prefix is stripped by load_modules; entries are pre-sorted).
+_setup_module_registry() {
+    MODULES=()
+    for entry in "$@"; do
+        MODULES+=("$entry")
+    done
+}
+
+@test "resolve_module_deps: no deps keeps selection unchanged" {
+    # Arrange
+    declare -A MODULE_DEPS_MAP=()
+    declare -A MODULE_ID_SET=([zsh]=1 [git]=1)
+    _setup_module_registry "zsh|Zsh|desc|1" "git|Git|desc|1"
+    selected_module_ids=(zsh git)
+
+    # Act (use run -- no variable mutation to check)
+    run resolve_module_deps
+
+    # Assert: no changes, no output
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "resolve_module_deps: direct dependency is auto-added" {
+    # Arrange: claude-code depends on node
+    declare -A MODULE_DEPS_MAP=([claude-code]="node")
+    declare -A MODULE_ID_SET=([node]=1 [claude-code]=1)
+    _setup_module_registry "node|Node.js|desc|1" "claude-code|Claude Code|desc|1"
+    selected_module_ids=(claude-code)
+
+    # Act (call directly so selected_module_ids is modified in this shell)
+    resolve_module_deps
+
+    # Assert: node was added
+    array_contains "node" "${selected_module_ids[@]}"
+}
+
+@test "resolve_module_deps: direct dep is sorted by MODULE_ORDER" {
+    # Arrange: claude-code depends on node; node appears first in MODULES
+    declare -A MODULE_DEPS_MAP=([claude-code]="node")
+    declare -A MODULE_ID_SET=([node]=1 [claude-code]=1)
+    _setup_module_registry "node|Node.js|desc|1" "claude-code|Claude Code|desc|1"
+    selected_module_ids=(claude-code)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: node comes before claude-code after re-sort
+    [ "${selected_module_ids[0]}" = "node" ]
+    [ "${selected_module_ids[1]}" = "claude-code" ]
+}
+
+@test "resolve_module_deps: transitive dependencies are resolved" {
+    # Arrange: A depends on B, B depends on C
+    declare -A MODULE_DEPS_MAP=([modA]="modB" [modB]="modC")
+    declare -A MODULE_ID_SET=([modA]=1 [modB]=1 [modC]=1)
+    _setup_module_registry "modC|Module C|desc|1" "modB|Module B|desc|1" "modA|Module A|desc|1"
+    selected_module_ids=(modA)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: both modB and modC were added
+    array_contains "modB" "${selected_module_ids[@]}"
+    array_contains "modC" "${selected_module_ids[@]}"
+}
+
+@test "resolve_module_deps: transitive deps sorted by MODULE_ORDER" {
+    # Arrange: A depends on B, B depends on C
+    # MODULES order: C first, then B, then A (simulating ascending ORDER)
+    declare -A MODULE_DEPS_MAP=([modA]="modB" [modB]="modC")
+    declare -A MODULE_ID_SET=([modA]=1 [modB]=1 [modC]=1)
+    _setup_module_registry "modC|Module C|desc|1" "modB|Module B|desc|1" "modA|Module A|desc|1"
+    selected_module_ids=(modA)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: order is modC, modB, modA (follows MODULES order)
+    [ "${selected_module_ids[0]}" = "modC" ]
+    [ "${selected_module_ids[1]}" = "modB" ]
+    [ "${selected_module_ids[2]}" = "modA" ]
+}
+
+@test "resolve_module_deps: already selected dep is not duplicated" {
+    # Arrange: claude-code depends on node, but node is already selected
+    declare -A MODULE_DEPS_MAP=([claude-code]="node")
+    declare -A MODULE_ID_SET=([node]=1 [claude-code]=1)
+    _setup_module_registry "node|Node.js|desc|1" "claude-code|Claude Code|desc|1"
+    selected_module_ids=(node claude-code)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: no duplicate -- still exactly 2 entries
+    [ "${#selected_module_ids[@]}" -eq 2 ]
+}
+
+@test "resolve_module_deps: multiple deps of one module are all added" {
+    # Arrange: modA depends on both modB and modC
+    declare -A MODULE_DEPS_MAP=([modA]="modB modC")
+    declare -A MODULE_ID_SET=([modA]=1 [modB]=1 [modC]=1)
+    _setup_module_registry "modB|Module B|desc|1" "modC|Module C|desc|1" "modA|Module A|desc|1"
+    selected_module_ids=(modA)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: both added
+    array_contains "modB" "${selected_module_ids[@]}"
+    array_contains "modC" "${selected_module_ids[@]}"
+    [ "${#selected_module_ids[@]}" -eq 3 ]
+}
+
+@test "resolve_module_deps: unknown dep warns but does not fail" {
+    # Arrange: modA depends on nonexistent, which is not in MODULE_ID_SET
+    declare -A MODULE_DEPS_MAP=([modA]="nonexistent")
+    declare -A MODULE_ID_SET=([modA]=1)
+    _setup_module_registry "modA|Module A|desc|1"
+    selected_module_ids=(modA)
+
+    # Act (use run to capture warning output)
+    run resolve_module_deps
+
+    # Assert: warning shown, no crash
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"見つかりません"* ]]
+}
+
+@test "resolve_module_deps: diamond dependency resolved without duplicates" {
+    # Arrange: modA -> modB, modA -> modC, modB -> modD, modC -> modD
+    declare -A MODULE_DEPS_MAP=([modA]="modB modC" [modB]="modD" [modC]="modD")
+    declare -A MODULE_ID_SET=([modA]=1 [modB]=1 [modC]=1 [modD]=1)
+    _setup_module_registry "modD|Module D|desc|1" "modB|Module B|desc|1" "modC|Module C|desc|1" "modA|Module A|desc|1"
+    selected_module_ids=(modA)
+
+    # Act
+    resolve_module_deps
+
+    # Assert: all 4 modules present, no duplicates
+    [ "${#selected_module_ids[@]}" -eq 4 ]
+    array_contains "modD" "${selected_module_ids[@]}"
+    # modD should come first (lowest in MODULES order)
+    [ "${selected_module_ids[0]}" = "modD" ]
+}


### PR DESCRIPTION
## 概要

プロジェクト健全性チェック（2026-03-30）で検出された 7 件の指摘事項を修正。

Close #97

## 変更内容

### Important 修正
- **DESIGN.md**: Key Decisions テーブルを現状に更新（`.shell/` 共有方式、macOS 対応済み）
- **claude-code.sh**: `MODULE_DEPS="node"` 追加（codex-cli/gemini-cli と同様に依存宣言）
- **test_backup_sort.bats**: 陳腐化した zsh glob テストを `find_newest_backup()` の動作テスト 5 件に完全置換

### Minor 修正
- **README.md**: ディレクトリツリーに `dotfiles/tests/` を追加
- **テストヘルパー共通化**: `_source_setup_functions` を `helpers/setup_functions.bash` に切り出し
- **テスト追加**: `ensure_node` 6 件 + `resolve_module_deps` 9 件 = 15 件の新規テスト

## テスト計画

- [x] BATS テスト全 76 件 pass（新規 20 件、書き換え 5 件）
- [x] shfmt / shellcheck pass（新規警告なし）