### PR TITLE
feat: zsh モジュールにインストール・デフォルトシェル変更機能を追加

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -1,5 +1,8 @@
 # ~/.zshrc
 
+# Guard: skip when sourced by a non-zsh shell (e.g., bash in Claude Code)
+[[ -n "$ZSH_VERSION" ]] || return 0
+
 # Powerlevel10k の instant prompt を有効化
 if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
     source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -67,12 +67,15 @@ _zsh_ensure_installed() {
             return 1
         fi
         msg_info "zsh をインストールします..."
+        run_cmd sudo apt-get update -qq || {
+            msg_warn "apt-get update に失敗しました。古いパッケージインデックスのまま zsh のインストールを試行します。"
+        }
         run_cmd sudo apt-get install -y zsh || {
             msg_error "zsh のインストールに失敗しました。"
             return 1
         }
         if ((!DRY_RUN)); then
-            msg_success "zsh $(zsh --version 2>/dev/null | head -1) をインストールしました。"
+            msg_success "$(zsh --version 2>/dev/null | head -1) をインストールしました。"
         fi
         ;;
     *)
@@ -87,11 +90,14 @@ _zsh_set_default_shell() {
     local zsh_path
     zsh_path=$(command -v zsh)
 
+    local real_user
+    real_user="${SUDO_USER:-$(id -un)}"
+
     local current_shell
     if command -v getent >/dev/null 2>&1; then
-        current_shell=$(getent passwd "$USER" | cut -d: -f7)
+        current_shell=$(getent passwd "$real_user" | cut -d: -f7)
     elif command -v dscl >/dev/null 2>&1; then
-        current_shell=$(dscl . -read "/Users/$USER" UserShell | awk '{print $2}')
+        current_shell=$(dscl . -read "/Users/$real_user" UserShell | awk '{print $2}')
     else
         msg_warn "現在のデフォルトシェルを確認できません。"
         current_shell=""
@@ -103,7 +109,7 @@ _zsh_set_default_shell() {
     fi
 
     msg_info "デフォルトシェルを zsh ($zsh_path) に変更します..."
-    run_cmd sudo chsh -s "$zsh_path" "$USER" || {
+    run_cmd sudo chsh -s "$zsh_path" "$real_user" || {
         msg_error "デフォルトシェルの変更に失敗しました。"
         msg_step "手動で実行してください: chsh -s $zsh_path" >&2
         return 1
@@ -205,7 +211,9 @@ setup_zsh() {
     done
 
     # デフォルトシェルを zsh に変更
-    _zsh_set_default_shell || true
+    if ! _zsh_set_default_shell; then
+        msg_warn "デフォルトシェルの変更に失敗しましたが、zsh 設定のセットアップは続行します。"
+    fi
 
     msg_success "Zsh 設定一式のセットアップが完了しました。"
 }

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -34,10 +34,93 @@ ZSH_MOD_MANAGED_FILES=(
     "$SCRIPT_DIR/.shell/aliases.sh|$HOME/.shell/aliases.sh|aliases.sh|エイリアスは手動で設定してください。"
 )
 
+# --- ヘルパー: OS 判定 ---
+# Returns: "macos" / "linux" / "unknown"
+_zsh_detect_os() {
+    case "$OSTYPE" in
+    darwin*) printf '%s' "macos" ;;
+    linux*) printf '%s' "linux" ;;
+    *) printf '%s' "unknown" ;;
+    esac
+}
+
+# --- ヘルパー: zsh のインストール確認・実行 ---
+# Returns: 0=available, 1=failed
+_zsh_ensure_installed() {
+    if command -v zsh >/dev/null 2>&1; then
+        msg_info "zsh は既にインストールされています ($(zsh --version 2>/dev/null | head -1))。"
+        return 0
+    fi
+
+    local os
+    os=$(_zsh_detect_os)
+
+    case "$os" in
+    macos)
+        msg_error "zsh が見つかりません。macOS では通常プリインストールされています。"
+        msg_step "Homebrew でインストールしてください: brew install zsh" >&2
+        return 1
+        ;;
+    linux)
+        if ! command -v apt-get >/dev/null 2>&1; then
+            msg_error "apt-get が見つかりません。zsh を手動でインストールしてください。"
+            return 1
+        fi
+        msg_info "zsh をインストールします..."
+        run_cmd sudo apt-get install -y zsh || {
+            msg_error "zsh のインストールに失敗しました。"
+            return 1
+        }
+        if ((!DRY_RUN)); then
+            msg_success "zsh $(zsh --version 2>/dev/null | head -1) をインストールしました。"
+        fi
+        ;;
+    *)
+        msg_error "未対応の OS です (OSTYPE=${OSTYPE})。zsh を手動でインストールしてください。"
+        return 1
+        ;;
+    esac
+}
+
+# --- ヘルパー: デフォルトシェルを zsh に変更 ---
+_zsh_set_default_shell() {
+    local zsh_path
+    zsh_path=$(command -v zsh)
+
+    local current_shell
+    if command -v getent >/dev/null 2>&1; then
+        current_shell=$(getent passwd "$USER" | cut -d: -f7)
+    elif command -v dscl >/dev/null 2>&1; then
+        current_shell=$(dscl . -read "/Users/$USER" UserShell | awk '{print $2}')
+    else
+        msg_warn "現在のデフォルトシェルを確認できません。"
+        current_shell=""
+    fi
+
+    if [[ "$current_shell" == "$zsh_path" ]]; then
+        msg_info "デフォルトシェルは既に zsh ($zsh_path) です。"
+        return 0
+    fi
+
+    msg_info "デフォルトシェルを zsh ($zsh_path) に変更します..."
+    run_cmd sudo chsh -s "$zsh_path" "$USER" || {
+        msg_error "デフォルトシェルの変更に失敗しました。"
+        msg_step "手動で実行してください: chsh -s $zsh_path" >&2
+        return 1
+    }
+
+    if ((!DRY_RUN)); then
+        msg_success "デフォルトシェルを $zsh_path に変更しました。"
+    fi
+}
+
 # --- セットアップ ---
 setup_zsh() {
     msg_header "Zsh 設定一式"
     print_separator
+
+    # zsh のインストール確認・実行
+    _zsh_ensure_installed || return 1
 
     # 依存コマンドの確認
     if ! command -v git >/dev/null 2>&1; then
@@ -120,6 +203,9 @@ setup_zsh() {
         IFS='|' read -r src dst label hint <<<"$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
+
+    # デフォルトシェルを zsh に変更
+    _zsh_set_default_shell || true
 
     msg_success "Zsh 設定一式のセットアップが完了しました。"
 }


### PR DESCRIPTION
## Summary
- zsh 未インストール時に自動インストールする機能を追加（Linux: apt-get / macOS: ガイド表示）
- デフォルトシェルを zsh に変更する `_zsh_set_default_shell` ヘルパーを追加
- `.zshrc` に非 zsh シェル（例: Claude Code の bash）からソースされた際のガードを追加

## Test plan
- [ ] Linux 環境で zsh 未インストール状態から `setup.sh zsh` を実行し、zsh がインストールされることを確認
- [ ] zsh インストール済み環境でスキップされることを確認
- [ ] デフォルトシェルが zsh に変更されることを確認
- [ ] `.zshrc` が bash からソースされた際に即 return することを確認
- [ ] `--dry-run` モードで破壊的操作が実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)