### PR TITLE
feat: Node.js モジュールをデフォルト有効化

### DIFF
--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -7,7 +7,7 @@
 MODULE_ID="node"
 MODULE_NAME="Node.js 開発環境"
 MODULE_DESC="fnm + Node.js LTS (バージョン管理)"
-MODULE_DEFAULT=0
+MODULE_DEFAULT=1
 MODULE_ORDER=18
 
 # NOTE: モジュール固有の変数には衝突回避のため NODE_MOD_ プレフィックスを使用


### PR DESCRIPTION
## Summary
- `dotfiles/modules/node.sh` の `MODULE_DEFAULT=0` を `MODULE_DEFAULT=1` に変更
- `claude-code`、`gemini-cli`、`codex-cli` が `node` に依存しており、事実上の必須モジュールのためデフォルト有効化

Closes #101

## Test plan
- [ ] `setup.sh` のデフォルト選択に `node` が含まれることを確認
- [ ] `--dry-run` モードで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)