### PR TITLE
feat: env.sh に ~/.config/*/.env の一括読み込みを追加

### DIFF
--- a/dotfiles/.claude/scripts/quality-gate.sh
+++ b/dotfiles/.claude/scripts/quality-gate.sh
@@ -16,7 +16,7 @@ except:
 " 2>/dev/null)
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
-  exit 0
+    exit 0
 fi
 
 # 拡張子を取得
@@ -26,28 +26,28 @@ ISSUES=""
 
 # console.log チェック（JS/TS ファイル）
 if [[ "$EXT" =~ ^(js|ts|jsx|tsx)$ ]]; then
-  CONSOLE_COUNT=$(grep -c "console\.log" "$FILE_PATH" 2>/dev/null || echo "0")
-  if [ "$CONSOLE_COUNT" -gt 0 ]; then
-    ISSUES="${ISSUES}\n  ${CONSOLE_COUNT} console.log found in ${FILE_PATH}"
-  fi
+    CONSOLE_COUNT=$(grep -c "console\.log" "$FILE_PATH" 2>/dev/null || echo "0")
+    if [ "$CONSOLE_COUNT" -gt 0 ]; then
+        ISSUES="${ISSUES}\n  ${CONSOLE_COUNT} console.log found in ${FILE_PATH}"
+    fi
 fi
 
 # print() チェック（Python ファイル、テスト以外）
 if [[ "$EXT" == "py" ]] && [[ "$FILE_PATH" != *"test_"* ]] && [[ "$FILE_PATH" != *"_test.py" ]]; then
-  PRINT_COUNT=$(grep -cE "^\s*print\(" "$FILE_PATH" 2>/dev/null || echo "0")
-  if [ "$PRINT_COUNT" -gt 3 ]; then
-    ISSUES="${ISSUES}\n  ${PRINT_COUNT} print() calls in ${FILE_PATH} (use logging instead?)"
-  fi
+    PRINT_COUNT=$(grep -cE "^\s*print\(" "$FILE_PATH" 2>/dev/null || echo "0")
+    if [ "$PRINT_COUNT" -gt 3 ]; then
+        ISSUES="${ISSUES}\n  ${PRINT_COUNT} print() calls in ${FILE_PATH} (use logging instead?)"
+    fi
 fi
 
 # TODO/FIXME チェック（新規追加のみ -- git diffで確認）
 TODO_COUNT=$(git diff HEAD -- "$FILE_PATH" 2>/dev/null | grep "^+" | grep -ciE "(TODO|FIXME|HACK|XXX)" || echo "0")
 if [ "$TODO_COUNT" -gt 0 ]; then
-  ISSUES="${ISSUES}\n  ${TODO_COUNT} new TODO/FIXME added in ${FILE_PATH}"
+    ISSUES="${ISSUES}\n  ${TODO_COUNT} new TODO/FIXME added in ${FILE_PATH}"
 fi
 
 if [ -n "$ISSUES" ]; then
-  echo -e "$ISSUES" >&2
+    echo -e "$ISSUES" >&2
 fi
 
 exit 0

--- a/dotfiles/.claude/scripts/session-persist.sh
+++ b/dotfiles/.claude/scripts/session-persist.sh
@@ -14,7 +14,7 @@ WORKING_DIR=$(pwd)
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # セッションサマリーを保存
-cat > "$PERSIST_FILE" << EOF
+cat >"$PERSIST_FILE" <<EOF
 {
   "timestamp": "${TIMESTAMP}",
   "branch": "${BRANCH}",
@@ -25,6 +25,6 @@ cat > "$PERSIST_FILE" << EOF
 EOF
 
 # ツールコールカウンターをリセット
-echo "0" > "${HOME}/.claude/cache/.tool-call-count"
+echo "0" >"${HOME}/.claude/cache/.tool-call-count"
 
 exit 0

--- a/dotfiles/.claude/scripts/session-start.sh
+++ b/dotfiles/.claude/scripts/session-start.sh
@@ -5,19 +5,19 @@
 PERSIST_FILE="${HOME}/.claude/sessions/last-session.json"
 
 if [ -f "$PERSIST_FILE" ]; then
-  TIMESTAMP=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['timestamp'])" 2>/dev/null)
-  BRANCH=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['branch'])" 2>/dev/null)
-  LAST_COMMIT=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['last_commit'])" 2>/dev/null)
-  TOOL_CALLS=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['tool_calls'])" 2>/dev/null)
+    TIMESTAMP=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['timestamp'])" 2>/dev/null)
+    BRANCH=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['branch'])" 2>/dev/null)
+    LAST_COMMIT=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['last_commit'])" 2>/dev/null)
+    TOOL_CALLS=$(python3 -c "import json; print(json.load(open('$PERSIST_FILE'))['tool_calls'])" 2>/dev/null)
 
-  echo "Previous session: ${TIMESTAMP}" >&2
-  echo "   Branch: ${BRANCH}" >&2
-  echo "   Last commit: ${LAST_COMMIT}" >&2
-  echo "   Tool calls: ${TOOL_CALLS}" >&2
+    echo "Previous session: ${TIMESTAMP}" >&2
+    echo "   Branch: ${BRANCH}" >&2
+    echo "   Last commit: ${LAST_COMMIT}" >&2
+    echo "   Tool calls: ${TOOL_CALLS}" >&2
 fi
 
 # ツールコールカウンターを初期化
 mkdir -p "${HOME}/.claude/cache"
-echo "0" > "${HOME}/.claude/cache/.tool-call-count"
+echo "0" >"${HOME}/.claude/cache/.tool-call-count"
 
 exit 0

--- a/dotfiles/.claude/scripts/suggest-compact.sh
+++ b/dotfiles/.claude/scripts/suggest-compact.sh
@@ -9,22 +9,22 @@ REMINDER_INTERVAL=30
 # カウンターファイルの初期化（存在しない場合）
 mkdir -p "$(dirname "$COUNTER_FILE")"
 if [ ! -f "$COUNTER_FILE" ]; then
-  echo "0" > "$COUNTER_FILE"
+    echo "0" >"$COUNTER_FILE"
 fi
 
 # カウントをインクリメント
 COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo "0")
 COUNT=$((COUNT + 1))
-echo "$COUNT" > "$COUNTER_FILE"
+echo "$COUNT" >"$COUNTER_FILE"
 
 # 閾値チェック
 if [ "$COUNT" -eq "$THRESHOLD" ]; then
-  echo "Tool call count reached ${THRESHOLD}. Consider running /compact at a logical task boundary to free up context." >&2
+    echo "Tool call count reached ${THRESHOLD}. Consider running /compact at a logical task boundary to free up context." >&2
 elif [ "$COUNT" -gt "$THRESHOLD" ]; then
-  SINCE=$((COUNT - THRESHOLD))
-  if [ $((SINCE % REMINDER_INTERVAL)) -eq 0 ]; then
-    echo "${COUNT} tool calls in session. Consider /compact if switching tasks." >&2
-  fi
+    SINCE=$((COUNT - THRESHOLD))
+    if [ $((SINCE % REMINDER_INTERVAL)) -eq 0 ]; then
+        echo "${COUNT} tool calls in session. Consider /compact if switching tasks." >&2
+    fi
 fi
 
 exit 0

--- a/dotfiles/.shell/env.sh
+++ b/dotfiles/.shell/env.sh
@@ -1,13 +1,33 @@
 # ----------------------------
 # .env file loading
 # ----------------------------
-# Load environment variables from ~/.claude/.env (used for MCP server config, etc.)
+# Load environment variables from known .env locations.
 # Disable: set export DISABLE_DOTENV=1 in .zshenv/.bashrc etc.
+#
+# Sources:
+#   1. ~/.claude/.env        (MCP server config, etc.)
+#   2. ~/.config/*/.env      (service tokens: op, etc.)
+#
+# NOTE: 1password.sh has its own validated loader for ~/.config/op/.env.
+#       Generic loading here is a fallback for other services.
 # ----------------------------
 if [[ "${DISABLE_DOTENV:-0}" != "1" ]]; then
+    # ~/.claude/.env
     if [[ -f "$HOME/.claude/.env" ]]; then
         set -a
         source "$HOME/.claude/.env"
         set +a
     fi
+
+    # ~/.config/*/.env (skip files already handled by dedicated modules)
+    for _dotenv_file in "$HOME"/.config/*/.env(N); do
+        # Skip 1password token (handled by 1password.sh with validation)
+        [[ "$_dotenv_file" == */op/.env ]] && continue
+        if [[ -r "$_dotenv_file" ]]; then
+            set -a
+            source "$_dotenv_file"
+            set +a
+        fi
+    done
+    unset _dotenv_file
 fi

--- a/dotfiles/.shell/env.sh
+++ b/dotfiles/.shell/env.sh
@@ -27,6 +27,7 @@ if [[ "${DISABLE_DOTENV:-0}" != "1" ]]; then
         [[ "$_dotenv_file" == */op/.env ]] && continue
         if [[ -r "$_dotenv_file" ]]; then
             set -a
+            # shellcheck disable=SC1090
             source "$_dotenv_file"
             set +a
         fi

--- a/dotfiles/.shell/env.sh
+++ b/dotfiles/.shell/env.sh
@@ -20,7 +20,9 @@ if [[ "${DISABLE_DOTENV:-0}" != "1" ]]; then
     fi
 
     # ~/.config/*/.env (skip files already handled by dedicated modules)
-    for _dotenv_file in "$HOME"/.config/*/.env(N); do
+    for _dotenv_file in "$HOME"/.config/*/.env; do
+        # No matches — skip
+        [[ -e "$_dotenv_file" ]] || continue
         # Skip 1password token (handled by 1password.sh with validation)
         [[ "$_dotenv_file" == */op/.env ]] && continue
         if [[ -r "$_dotenv_file" ]]; then

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -132,7 +132,8 @@ _claude_mod_uninstall_rules_dir() {
     for file in "${dst_dir}"/*.md; do
         [[ -f "$file" ]] || continue
 
-        local label="rules/${lang}/$(basename "$file")"
+        local label
+        label="rules/${lang}/$(basename "$file")"
         local newest
         newest=$(find_newest_backup "${file}.backup."'*') || true
 


### PR DESCRIPTION
## Summary
- `dotfiles/.shell/env.sh` に `~/.config/*/.env` の一括読み込み機能を追加
- `~/.config/<service>/.env` にファイルを配置するだけで環境変数が自動読み込みされる
- `~/.config/op/.env` は `1password.sh` のバリデーション付きローダーに委譲するためスキップ

## Test plan
- [ ] `~/.config/op/.env` が env.sh でスキップされることを確認
- [ ] `~/.config/testservice/.env` を作成して読み込まれることを確認
- [ ] `DISABLE_DOTENV=1` で全体が無効化されることを確認