### PR TITLE
refactor: Dockerfile と docker-compose.yml を全面刷新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,13 @@ ARG NODE_VERSION=""
 ENV FNM_VERSION=${FNM_VERSION} \
     NODE_VERSION=${NODE_VERSION}
 COPY --chown=$USERNAME:$USERNAME dotfiles/ /tmp/dotfiles/
-RUN cd /tmp/dotfiles \
+# SETUP_MODULES 未指定で実行すると非 TTY フォールバックで --all 相当となり、
+# 既定で除外しているはずの Docker / AWS / 1Password まで入ってしまう。明示的に弾く。
+RUN if [ -z "${SETUP_MODULES// }" ]; then \
+        echo "ERROR: SETUP_MODULES is empty. Specify modules explicitly or pass '--all'." >&2; \
+        exit 1; \
+    fi \
+    && cd /tmp/dotfiles \
     && bash setup.sh $SETUP_MODULES --force \
     && rm -rf /tmp/dotfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM ubuntu:24.04
 
+# Ubuntu の既定 /bin/sh は dash で bash 拡張 (${var//pattern} 等) が使えないため
+# 全 RUN ステップを bash で実行する。pipefail でパイプ途中失敗も拾う。
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Tokyo \
     LANG=en_US.UTF-8 \
@@ -53,10 +57,16 @@ ARG NODE_VERSION=""
 ENV FNM_VERSION=${FNM_VERSION} \
     NODE_VERSION=${NODE_VERSION}
 COPY --chown=$USERNAME:$USERNAME dotfiles/ /tmp/dotfiles/
-# SETUP_MODULES 未指定で実行すると非 TTY フォールバックで --all 相当となり、
-# 既定で除外しているはずの Docker / AWS / 1Password まで入ってしまう。明示的に弾く。
-RUN if [ -z "${SETUP_MODULES// }" ]; then \
+# SETUP_MODULES の検証:
+# - 空文字 → 非 TTY フォールバックで --all 相当となり除外モジュールも入るため弾く
+# - 不正文字 (シェルメタ文字) → unquoted 展開でインジェクションになるため弾く
+#   許容: 英数字 / - / _ / 空白 のみ (例: "zsh node", "--all")
+RUN if [[ -z "${SETUP_MODULES// /}" ]]; then \
         echo "ERROR: SETUP_MODULES is empty. Specify modules explicitly or pass '--all'." >&2; \
+        exit 1; \
+    fi \
+    && if [[ ! "$SETUP_MODULES" =~ ^[A-Za-z0-9_[:space:]-]+$ ]]; then \
+        echo "ERROR: SETUP_MODULES contains invalid characters. Allowed: [A-Za-z0-9_-] and spaces." >&2; \
         exit 1; \
     fi \
     && cd /tmp/dotfiles \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,31 @@
+# syntax=docker/dockerfile:1.7
 # ==============================================
 # 開発環境コンテナ
-# setup.sh --all で全モジュールをプリインストールした Zsh 環境
+# setup.sh で選択したモジュールをインストールした Zsh 環境
 # ==============================================
 
 FROM ubuntu:24.04
 
-# 対話的プロンプトを抑制
 ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=Asia/Tokyo
+ENV TZ=Asia/Tokyo \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
 
-# 全モジュールの前提パッケージを一括インストール
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    # 基本ツール
-    zsh \
-    git \
-    curl \
-    wget \
-    unzip \
-    sudo \
-    ca-certificates \
-    locales \
-    # modern-cli (eza) 用
-    gpg \
-    # Python ビルド依存パッケージ
-    build-essential \
-    libssl-dev \
-    zlib1g-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    libncursesw5-dev \
-    xz-utils \
-    tk-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    libffi-dev \
-    liblzma-dev \
-    && rm -rf /var/lib/apt/lists/*
+# BuildKit cache mount を使って apt 取得を高速化
+# NOTE: docker-clean が cache を毎回消すため最初に削除する
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        zsh git curl wget unzip sudo ca-certificates locales gpg jq \
+        build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+        libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev \
+        libxmlsec1-dev libffi-dev liblzma-dev \
+    && locale-gen en_US.UTF-8
 
-# ロケール設定
-RUN locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
-
-# 非 root ユーザーの作成（パスワードなし sudo）
+# 非 root ユーザー（パスワードなし sudo）
 ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -54,28 +35,22 @@ RUN userdel -r ubuntu 2>/dev/null || true \
     && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# fnm + Node.js LTS を事前インストール
-# NOTE: ピン留めされたバージョンの公式バイナリを GitHub Releases から直接取得する
-ARG FNM_VERSION=v1.38.1
 USER $USERNAME
-ENV FNM_DIR="/home/${USERNAME}/.local/share/fnm"
-RUN mkdir -p /home/${USERNAME}/.local/bin \
-    && curl -fsSL "https://github.com/Schniz/fnm/releases/download/${FNM_VERSION}/fnm-linux.zip" \
-       -o /tmp/fnm.zip \
-    && unzip -o /tmp/fnm.zip -d /home/${USERNAME}/.local/bin \
-    && chmod +x /home/${USERNAME}/.local/bin/fnm \
-    && rm /tmp/fnm.zip \
-    && export PATH="/home/${USERNAME}/.local/bin:$PATH" \
-    && eval "$(fnm env)" \
-    && fnm install --lts \
-    && fnm default lts-latest
-ENV PATH="/home/${USERNAME}/.local/bin:$PATH"
-
-# dotfiles をコピーして setup.sh を実行
 WORKDIR /home/$USERNAME
+
+# setup.sh で導入するモジュール
+# Docker / AWS CLI / 1Password はコンテナ内で動作しないため既定で除外
+# node モジュールが fnm + Node.js LTS を multi-arch でインストールする
+# 上書きするには docker compose build --build-arg SETUP_MODULES="..." を使う
+ARG SETUP_MODULES="zsh git modern-cli node python claude-code codex-cli gemini-cli gh copilot-cli"
 COPY --chown=$USERNAME:$USERNAME dotfiles/ /tmp/dotfiles/
-RUN cd /tmp/dotfiles && zsh setup.sh --all \
+RUN cd /tmp/dotfiles \
+    && zsh setup.sh $SETUP_MODULES --force \
     && rm -rf /tmp/dotfiles
 
 WORKDIR /workspaces
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD command -v zsh >/dev/null && command -v git >/dev/null || exit 1
+
 CMD ["zsh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,17 @@ WORKDIR /home/$USERNAME
 
 # setup.sh で導入するモジュール
 # Docker / AWS CLI / 1Password はコンテナ内で動作しないため既定で除外
-# node モジュールが fnm + Node.js LTS を multi-arch でインストールする
+# node モジュールが fnm + Node.js を multi-arch でインストールする
 # 上書きするには docker compose build --build-arg SETUP_MODULES="..." を使う
+# 再現性のため FNM_VERSION / NODE_VERSION も build-arg で固定可能
 ARG SETUP_MODULES="zsh git modern-cli node python claude-code codex-cli gemini-cli gh copilot-cli"
+ARG FNM_VERSION=""
+ARG NODE_VERSION=""
+ENV FNM_VERSION=${FNM_VERSION} \
+    NODE_VERSION=${NODE_VERSION}
 COPY --chown=$USERNAME:$USERNAME dotfiles/ /tmp/dotfiles/
 RUN cd /tmp/dotfiles \
-    && zsh setup.sh $SETUP_MODULES --force \
+    && bash setup.sh $SETUP_MODULES --force \
     && rm -rf /tmp/dotfiles
 
 WORKDIR /workspaces

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,19 @@ ENV TZ=Asia/Tokyo \
     LC_ALL=en_US.UTF-8
 
 # BuildKit cache mount を使って apt 取得を高速化
-# NOTE: docker-clean が cache を毎回消すため最初に削除する
+# NOTE: docker-clean が cache を毎回消すためビルド中だけ退避し、最終イメージには元の挙動を復元する
+#       (runtime で apt-get を使うユーザーが cache 蓄積に悩まないため)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    mv /etc/apt/apt.conf.d/docker-clean /tmp/docker-clean.bak \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         zsh git curl wget unzip sudo ca-certificates locales gpg jq \
         build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
         libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev \
         libxmlsec1-dev libffi-dev liblzma-dev \
-    && locale-gen en_US.UTF-8
+    && locale-gen en_US.UTF-8 \
+    && mv /tmp/docker-clean.bak /etc/apt/apt.conf.d/docker-clean
 
 # 非 root ユーザー（パスワードなし sudo）
 ARG USERNAME=dev
@@ -41,8 +43,10 @@ WORKDIR /home/$USERNAME
 # setup.sh で導入するモジュール
 # Docker / AWS CLI / 1Password はコンテナ内で動作しないため既定で除外
 # node モジュールが fnm + Node.js を multi-arch でインストールする
-# 上書きするには docker compose build --build-arg SETUP_MODULES="..." を使う
-# 再現性のため FNM_VERSION / NODE_VERSION も build-arg で固定可能
+# 上書き方法:
+#   1) Compose 経由 (推奨): SETUP_MODULES="..." docker compose build
+#   2) 直接 build-arg:      docker compose build --build-arg SETUP_MODULES="..."
+# 再現性のため FNM_VERSION / NODE_VERSION も同じ手順で固定可能
 ARG SETUP_MODULES="zsh git modern-cli node python claude-code codex-cli gemini-cli gh copilot-cli"
 ARG FNM_VERSION=""
 ARG NODE_VERSION=""

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ SETUP_MODULES="zsh node claude-code" docker compose build
 
 #### Multi-arch ビルド
 
-`linux/amd64` / `linux/arm64` (Apple Silicon) / `linux/arm` に対応しています。`node` モジュールがホストアーキテクチャを判定して fnm の適切なアセットを取得します。
+`linux/amd64` と `linux/arm64` (Apple Silicon) に対応しています。`node` モジュールが `uname -m` を判定して fnm の適切なアセットを取得します (ubuntu:24.04 は `linux/arm/v7` 公式イメージが未提供のため arm32 は非対応)。
 
 ### API キーの設定
 

--- a/README.md
+++ b/README.md
@@ -256,21 +256,40 @@ VS Code / Cursor から Dev Containers として接続する場合は、コマ�
 
 ### 含まれるツール
 
-コンテナイメージには `setup.sh --all` で全モジュールがプリインストールされています:
+コンテナイメージには、コンテナ内で動作するモジュールが既定でプリインストールされます:
 
 - Zsh + Zinit + Powerlevel10k
 - Git グローバル設定
-- 1Password CLI + SSH エージェント + Git 署名
 - モダン CLI ツール (eza, bat, fd, ripgrep)
 - Node.js (fnm + LTS)
-- Docker Engine + Compose
-- Claude Code
-- AWS CLI v2
 - Python (pyenv + uv)
-- Gemini CLI
+- Claude Code
 - Codex CLI
+- Gemini CLI
 - GitHub CLI
 - GitHub Copilot CLI
+
+**既定で除外**されるモジュール (コンテナ内で動作しない / 不要なため):
+
+- Docker Engine (Docker-in-Docker 用途は別途 socket マウントが必要)
+- AWS CLI v2 (必要に応じて手動インストール)
+- 1Password (ホストでの SSH エージェントが前提)
+
+#### モジュール選択のカスタマイズ
+
+`SETUP_MODULES` 環境変数を指定するとビルド時のモジュールを上書きできます:
+
+```bash
+# 全モジュール入り (Docker は build 時にエラーになる可能性あり)
+SETUP_MODULES="--all" docker compose build
+
+# 最小構成 (Zsh + Node + Claude Code のみ)
+SETUP_MODULES="zsh node claude-code" docker compose build
+```
+
+#### Multi-arch ビルド
+
+`linux/amd64` / `linux/arm64` (Apple Silicon) / `linux/arm` に対応しています。`node` モジュールがホストアーキテクチャを判定して fnm の適切なアセットを取得します。
 
 ### API キーの設定
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
         FNM_VERSION: ${FNM_VERSION:-}
         NODE_VERSION: ${NODE_VERSION:-}
     init: true
+    # コンテナ内プロセスが setuid バイナリ等で追加権限を獲得できないようにする
+    security_opt:
+      - "no-new-privileges:true"
     volumes:
       - .:/workspaces/dev-templates
       - ~/.ssh:/home/dev/.ssh:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
         # コンテナ内で動かないモジュール (Docker / AWS / 1Password) は既定で除外
         # 全モジュール入りにする場合は SETUP_MODULES に "--all" を指定する
         SETUP_MODULES: ${SETUP_MODULES:-zsh git modern-cli node python claude-code codex-cli gemini-cli gh copilot-cli}
+        # fnm / Node.js を固定したい場合は環境変数で指定 (例: FNM_VERSION=v1.38.1 NODE_VERSION=22)
+        # 空の場合は latest / --lts
+        FNM_VERSION: ${FNM_VERSION:-}
+        NODE_VERSION: ${NODE_VERSION:-}
     init: true
     volumes:
       - .:/workspaces/dev-templates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # コンテナ内で動かないモジュール (Docker / AWS / 1Password) は既定で除外
+        # 全モジュール入りにする場合は SETUP_MODULES に "--all" を指定する
+        SETUP_MODULES: ${SETUP_MODULES:-zsh git modern-cli node python claude-code codex-cli gemini-cli gh copilot-cli}
+    init: true
     volumes:
       - .:/workspaces/dev-templates
       - ~/.ssh:/home/dev/.ssh:ro

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -16,8 +16,24 @@ NODE_MOD_FNM_BIN_DIR="$HOME/.local/bin"
 # NOTE: 既定では latest リリースを取得する。再現性が必要な場合は環境変数で固定する
 #   FNM_VERSION=v1.38.1 ... fnm 自体のバージョン (Linux のみ。macOS は brew 任せ)
 #   NODE_VERSION=22      ... fnm install で取得する Node のバージョン (空なら --lts)
+# 前後空白をトリムしてから検証する
 NODE_MOD_FNM_VERSION="${FNM_VERSION:-}"
+NODE_MOD_FNM_VERSION="${NODE_MOD_FNM_VERSION#"${NODE_MOD_FNM_VERSION%%[![:space:]]*}"}"
+NODE_MOD_FNM_VERSION="${NODE_MOD_FNM_VERSION%"${NODE_MOD_FNM_VERSION##*[![:space:]]}"}"
 NODE_MOD_NODE_VERSION="${NODE_VERSION:-}"
+NODE_MOD_NODE_VERSION="${NODE_MOD_NODE_VERSION#"${NODE_MOD_NODE_VERSION%%[![:space:]]*}"}"
+NODE_MOD_NODE_VERSION="${NODE_MOD_NODE_VERSION%"${NODE_MOD_NODE_VERSION##*[![:space:]]}"}"
+
+# 値検証: シェルインジェクション防止と早期エラー
+if [[ -n "$NODE_MOD_FNM_VERSION" && ! "$NODE_MOD_FNM_VERSION" =~ ^v?[0-9]+(\.[0-9]+)*$ ]]; then
+    printf 'ERROR: FNM_VERSION の形式が不正です: %q (例: v1.38.1)\n' "$NODE_MOD_FNM_VERSION" >&2
+    return 1 2>/dev/null || exit 1
+fi
+if [[ -n "$NODE_MOD_NODE_VERSION" && ! "$NODE_MOD_NODE_VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    printf 'ERROR: NODE_VERSION の形式が不正です: %q (例: 22, v22.1.0, lts/iron)\n' "$NODE_MOD_NODE_VERSION" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 if [[ -n "$NODE_MOD_FNM_VERSION" ]]; then
     NODE_MOD_FNM_REPO="https://github.com/Schniz/fnm/releases/download/${NODE_MOD_FNM_VERSION}"
 else
@@ -285,16 +301,29 @@ _node_install_lts() {
     fi
 
     msg_info "${label} をインストールします..."
-    fnm install "$install_arg" || {
-        msg_error "${label} のインストールに失敗しました。"
-        msg_step "手動でインストールしてください: fnm install ${install_arg}" >&2
+    # stderr を一時ファイル経由でキャプチャし、失敗時に再出力する
+    local fnm_install_err
+    fnm_install_err=$(mktemp /tmp/fnm-install-err-XXXXXXXXXX) || {
+        msg_error "一時ファイルの作成に失敗しました。"
         return 1
     }
+    if ! fnm install "$install_arg" 2>"$fnm_install_err"; then
+        msg_error "${label} のインストールに失敗しました。"
+        if [[ -s "$fnm_install_err" ]]; then
+            printf '  fnm stderr: ' >&2
+            cat "$fnm_install_err" >&2
+        fi
+        msg_step "手動でインストールしてください: fnm install ${install_arg}" >&2
+        rm -f "$fnm_install_err"
+        return 1
+    fi
+    rm -f "$fnm_install_err"
 
-    # デフォルトバージョンに設定
-    fnm default "$default_arg" 2>/dev/null || {
-        msg_warn "デフォルトバージョンの設定に失敗しました。"
-    }
+    # デフォルトバージョンに設定 (stderr を握り潰さず警告で出す)
+    local fnm_default_err
+    if ! fnm_default_err=$(fnm default "$default_arg" 2>&1 >/dev/null); then
+        msg_warn "デフォルトバージョンの設定に失敗しました: ${fnm_default_err}"
+    fi
 
     # fnm env を再評価して node を PATH に通す
     eval "$(fnm env)"

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -13,8 +13,16 @@ MODULE_ORDER=18
 # NOTE: モジュール固有の変数には衝突回避のため NODE_MOD_ プレフィックスを使用
 
 NODE_MOD_FNM_BIN_DIR="$HOME/.local/bin"
-# NOTE: 常に最新リリースをインストールする（GitHub の /latest リダイレクトを利用）
-NODE_MOD_FNM_REPO="https://github.com/Schniz/fnm/releases/latest/download"
+# NOTE: 既定では latest リリースを取得する。再現性が必要な場合は環境変数で固定する
+#   FNM_VERSION=v1.38.1 ... fnm 自体のバージョン (Linux のみ。macOS は brew 任せ)
+#   NODE_VERSION=22      ... fnm install で取得する Node のバージョン (空なら --lts)
+NODE_MOD_FNM_VERSION="${FNM_VERSION:-}"
+NODE_MOD_NODE_VERSION="${NODE_VERSION:-}"
+if [[ -n "$NODE_MOD_FNM_VERSION" ]]; then
+    NODE_MOD_FNM_REPO="https://github.com/Schniz/fnm/releases/download/${NODE_MOD_FNM_VERSION}"
+else
+    NODE_MOD_FNM_REPO="https://github.com/Schniz/fnm/releases/latest/download"
+fi
 
 # 管理対象ファイル（配布元パス, 配置先パス, 表示名, 未検出時メッセージ）
 NODE_MOD_MANAGED_FILES=(
@@ -229,16 +237,28 @@ _node_setup_linux() {
     fi
 }
 
-# --- Node.js LTS インストール ---
+# --- Node.js インストール ---
+# NODE_VERSION 環境変数が設定されていればそのバージョン、未設定なら LTS をインストール
 _node_install_lts() {
+    local install_arg default_arg label
+    if [[ -n "$NODE_MOD_NODE_VERSION" ]]; then
+        install_arg="$NODE_MOD_NODE_VERSION"
+        default_arg="$NODE_MOD_NODE_VERSION"
+        label="Node.js ${NODE_MOD_NODE_VERSION}"
+    else
+        install_arg="--lts"
+        default_arg="lts-latest"
+        label="Node.js LTS"
+    fi
+
     if ((DRY_RUN)); then
-        msg_dry_run "fnm install --lts"
-        msg_dry_run "fnm default lts-latest"
+        msg_dry_run "fnm install ${install_arg}"
+        msg_dry_run "fnm default ${default_arg}"
         return 0
     fi
 
     if ! command -v fnm >/dev/null 2>&1; then
-        msg_warn "fnm が PATH に見つかりません。Node.js LTS のインストールをスキップします。"
+        msg_warn "fnm が PATH に見つかりません。${label} のインストールをスキップします。"
         return 0
     fi
 
@@ -253,26 +273,26 @@ _node_install_lts() {
         fi
 
         if ((UPGRADE)); then
-            msg_info "Node.js LTS のアップグレードを実行します... (現在: ${node_ver:-unknown})"
+            msg_info "${label} のアップグレードを実行します... (現在: ${node_ver:-unknown})"
         elif [[ "$node_major" =~ ^[0-9]+$ ]] && ((node_major >= 18)); then
             msg_info "Node.js は既にインストールされています (${node_ver})。スキップします。"
             return 0
         elif [[ "$node_major" =~ ^[0-9]+$ ]] && ((node_major < 18)); then
-            msg_warn "既存の Node.js (${node_ver}) は推奨バージョン (v18 以上) 未満です。fnm で LTS をインストールします。"
+            msg_warn "既存の Node.js (${node_ver}) は推奨バージョン (v18 以上) 未満です。fnm で ${label} をインストールします。"
         else
-            msg_warn "Node.js のバージョンを特定できません (${node_ver:-unknown})。fnm で LTS をインストールします。"
+            msg_warn "Node.js のバージョンを特定できません (${node_ver:-unknown})。fnm で ${label} をインストールします。"
         fi
     fi
 
-    msg_info "Node.js LTS をインストールします..."
-    fnm install --lts || {
-        msg_error "Node.js LTS のインストールに失敗しました。"
-        msg_step "手動でインストールしてください: fnm install --lts" >&2
+    msg_info "${label} をインストールします..."
+    fnm install "$install_arg" || {
+        msg_error "${label} のインストールに失敗しました。"
+        msg_step "手動でインストールしてください: fnm install ${install_arg}" >&2
         return 1
     }
 
     # デフォルトバージョンに設定
-    fnm default lts-latest 2>/dev/null || {
+    fnm default "$default_arg" 2>/dev/null || {
         msg_warn "デフォルトバージョンの設定に失敗しました。"
     }
 

--- a/dotfiles/modules/node.sh
+++ b/dotfiles/modules/node.sh
@@ -29,9 +29,12 @@ if [[ -n "$NODE_MOD_FNM_VERSION" && ! "$NODE_MOD_FNM_VERSION" =~ ^v?[0-9]+(\.[0-
     printf 'ERROR: FNM_VERSION の形式が不正です: %q (例: v1.38.1)\n' "$NODE_MOD_FNM_VERSION" >&2
     return 1 2>/dev/null || exit 1
 fi
-if [[ -n "$NODE_MOD_NODE_VERSION" && ! "$NODE_MOD_NODE_VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-    printf 'ERROR: NODE_VERSION の形式が不正です: %q (例: 22, v22.1.0, lts/iron)\n' "$NODE_MOD_NODE_VERSION" >&2
-    return 1 2>/dev/null || exit 1
+if [[ -n "$NODE_MOD_NODE_VERSION" ]]; then
+    # パストラバーサル防止: ".." 部分文字列を明示的に弾く
+    if [[ "$NODE_MOD_NODE_VERSION" == *..* ]] || [[ ! "$NODE_MOD_NODE_VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+        printf 'ERROR: NODE_VERSION の形式が不正です: %q (例: 22, v22.1.0, lts/iron)\n' "$NODE_MOD_NODE_VERSION" >&2
+        return 1 2>/dev/null || exit 1
+    fi
 fi
 
 if [[ -n "$NODE_MOD_FNM_VERSION" ]]; then
@@ -302,11 +305,14 @@ _node_install_lts() {
 
     msg_info "${label} をインストールします..."
     # stderr を一時ファイル経由でキャプチャし、失敗時に再出力する
+    # trap で SIGINT / 関数 RETURN 時にも確実にクリーンアップする
     local fnm_install_err
     fnm_install_err=$(mktemp /tmp/fnm-install-err-XXXXXXXXXX) || {
         msg_error "一時ファイルの作成に失敗しました。"
         return 1
     }
+    # shellcheck disable=SC2064 # 即時展開で fnm_install_err の値を埋め込む
+    trap "rm -f '$fnm_install_err'" RETURN
     if ! fnm install "$install_arg" 2>"$fnm_install_err"; then
         msg_error "${label} のインストールに失敗しました。"
         if [[ -s "$fnm_install_err" ]]; then
@@ -314,10 +320,8 @@ _node_install_lts() {
             cat "$fnm_install_err" >&2
         fi
         msg_step "手動でインストールしてください: fnm install ${install_arg}" >&2
-        rm -f "$fnm_install_err"
         return 1
     fi
-    rm -f "$fnm_install_err"
 
     # デフォルトバージョンに設定 (stderr を握り潰さず警告で出す)
     local fnm_default_err


### PR DESCRIPTION
## Summary

Dev container 用 Dockerfile と docker-compose.yml を全面的に見直し、コンテナ内で動作しないモジュールを既定で除外しつつ、ビルド高速化・PID 1 init 対応・multi-arch 対応・カスタマイズ性を向上。

### Dockerfile

- \`# syntax=docker/dockerfile:1.7\` を宣言、BuildKit cache mount で apt 取得を高速化
- \`jq\` を base packages に追加 (Claude Code の MCP 設定マージで必要)
- 重複していた fnm 事前インストールを廃止し、\`node\` モジュールに委譲 (multi-arch も内部処理)
- \`SETUP_MODULES\` build-arg を導入し、Docker / AWS CLI / 1Password を既定で除外
- \`setup.sh\` を \`--force\` で完全非対話化
- \`HEALTHCHECK\` を追加 (zsh / git の存在確認)
- ENV を統合 (TZ / LANG 系を 1 ブロックに)

### docker-compose.yml

- \`init: true\` で PID 1 zombie プロセス問題を解消
- \`SETUP_MODULES\` を environment 経由で上書き可能に

### README.md

- 「含まれるツール」を既定構成 / 除外モジュールに分けて記載
- \`SETUP_MODULES\` カスタマイズ手順を追記
- multi-arch (amd64 / arm64) 対応を明記

## Test plan

- [ ] \`docker compose config\` で構文確認 (実施済み)
- [ ] \`docker compose build\` でイメージビルド成功確認
- [ ] \`docker compose up -d && docker compose exec devcontainer zsh\` で起動確認
- [ ] コンテナ内で \`claude\`, \`gemini\`, \`codex\`, \`copilot\`, \`gh\` が動作するか
- [ ] \`SETUP_MODULES="zsh node" docker compose build\` で最小構成ビルド成功確認
- [ ] Apple Silicon (arm64) でのビルド検証