### PR TITLE
feat(docker): UID/GID をホストと同期可能にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ GOOGLE_CLOUD_PROJECT=
 
 # Brave Search MCP
 BRAVE_API_KEY=
+
+# Docker bind mount のファイル所有をホストと一致させる
+# 未指定時は 1000:1000。$(id -u) / $(id -g) で取得可能
+# USER_UID=1000
+# USER_GID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,18 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN set -e \
-    # root への昇格を防ぐため UID/GID 0 を明示的に拒否
-    && if [[ "$USER_UID" == "0" || "$USER_GID" == "0" ]]; then \
-        echo "ERROR: USER_UID / USER_GID must not be 0 (root)." >&2; exit 1; \
+    # 既に dev ユーザーが存在するなら何もしない (再ビルドや BuildKit キャッシュ層の安全策)
+    && if id -u "$USERNAME" >/dev/null 2>&1; then \
+        echo "User '$USERNAME' already exists, skipping creation."; exit 0; \
+    fi \
+    # 数値バリデーション: 正の整数のみ許可 (1〜60000)
+    # - 先頭 0 ("00") / 負数 / 非数値 / 巨大値を弾く
+    # - "0" (root) を文字列ではなく数値範囲で拒否することでバイパス不可
+    && if ! [[ "$USER_UID" =~ ^[1-9][0-9]*$ ]] || (( USER_UID > 60000 )); then \
+        echo "ERROR: USER_UID must be a decimal integer 1-60000 (got: $USER_UID)." >&2; exit 1; \
+    fi \
+    && if ! [[ "$USER_GID" =~ ^[1-9][0-9]*$ ]] || (( USER_GID > 60000 )); then \
+        echo "ERROR: USER_GID must be a decimal integer 1-60000 (got: $USER_GID)." >&2; exit 1; \
     fi \
     # 既存ユーザー (ubuntu:24.04 の ubuntu は UID 1000) と UID 衝突する場合は削除
     && existing_user=$(getent passwd "$USER_UID" | cut -d: -f1 || true) \
@@ -48,6 +57,8 @@ RUN set -e \
         userdel -r "$existing_user" 2>/dev/null || true; \
     fi \
     # GID が既存グループ (例: ホスト GID 100 = users) と衝突する場合はそのグループを再利用
+    # NOTE: 結果として dev ユーザーのプライマリグループ名が dev ではなく既存名 (users 等) に
+    #       なる可能性がある。chown dev:dev は失敗するため chown dev:$(id -gn dev) を推奨
     && if ! getent group "$USER_GID" >/dev/null; then \
         groupadd --gid "$USER_GID" "$USERNAME"; \
     fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,26 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && mv /tmp/docker-clean.bak /etc/apt/apt.conf.d/docker-clean
 
 # 非 root ユーザー（パスワードなし sudo）
+# ホストの UID/GID をビルド時に渡せるようにし、bind mount したファイルの所有を一致させる
+#   docker compose build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
 ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-RUN userdel -r ubuntu 2>/dev/null || true \
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m -s /usr/bin/zsh $USERNAME \
+RUN set -e \
+    # root への昇格を防ぐため UID/GID 0 を明示的に拒否
+    && if [[ "$USER_UID" == "0" || "$USER_GID" == "0" ]]; then \
+        echo "ERROR: USER_UID / USER_GID must not be 0 (root)." >&2; exit 1; \
+    fi \
+    # 既存ユーザー (ubuntu:24.04 の ubuntu は UID 1000) と UID 衝突する場合は削除
+    && existing_user=$(getent passwd "$USER_UID" | cut -d: -f1 || true) \
+    && if [[ -n "$existing_user" && "$existing_user" != "$USERNAME" ]]; then \
+        userdel -r "$existing_user" 2>/dev/null || true; \
+    fi \
+    # GID が既存グループ (例: ホスト GID 100 = users) と衝突する場合はそのグループを再利用
+    && if ! getent group "$USER_GID" >/dev/null; then \
+        groupadd --gid "$USER_GID" "$USERNAME"; \
+    fi \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m -s /usr/bin/zsh "$USERNAME" \
     && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 

--- a/README.md
+++ b/README.md
@@ -245,13 +245,34 @@ Docker Compose + VS Code Dev Containers でコンテナ内に開発環境を構�
 cp .env.example .env
 # .env を編集して ANTHROPIC_API_KEY 等を設定
 
-# コンテナをビルド
-docker compose build
+# コンテナをビルド (ホストの UID/GID を渡して bind mount の所有を一致させるのを推奨)
+USER_UID=$(id -u) USER_GID=$(id -g) docker compose build
 
 # コンテナを起動
 docker compose up -d
 docker compose exec devcontainer zsh
 ```
+
+#### ホスト UID/GID の同期 (推奨)
+
+リポジトリは `.:/workspaces/dev-templates` として bind mount されるため、
+コンテナ内 `dev` ユーザーの UID/GID とホストユーザーが一致しないと、
+コンテナ内で作成したファイルがホスト側で異なる所有者に見えて編集権限の不整合や
+git の dubious ownership 警告を引き起こします (特にホスト UID が 1000 以外の場合)。
+
+`USER_UID` / `USER_GID` 環境変数を渡すことで一致させられます (未指定時は `1000:1000`):
+
+```bash
+# 一時的に渡す
+USER_UID=$(id -u) USER_GID=$(id -g) docker compose build
+
+# .env に永続化
+echo "USER_UID=$(id -u)" >> .env
+echo "USER_GID=$(id -g)" >> .env
+docker compose build
+```
+
+`.env` に書いておけば VS Code Dev Containers (Reopen in Container) でも同じビルド設定が使われます。
 
 VS Code / Cursor から Dev Containers として接続する場合は、コマンドパレットから「Dev Containers: Reopen in Container」を実行してください。
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ docker compose build
 
 `.env` に書いておけば VS Code Dev Containers (Reopen in Container) でも同じビルド設定が使われます。
 
+**注意事項**:
+- `USER_UID` / `USER_GID` は 1〜60000 の整数のみ許可されます (`0` / 先頭 0 付き / 非数値はビルド時に拒否)
+- ホスト GID が既存システムグループ (例: GID `100` = `users`、macOS の `20` = `staff`) と一致する場合、コンテナ内 `dev` ユーザーのプライマリグループは `dev` ではなく既存名 (`users` / `staff` 等) になります。`chown dev:dev` は失敗するため `chown dev:$(id -gn dev)` を使ってください
+
 VS Code / Cursor から Dev Containers として接続する場合は、コマンドパレットから「Dev Containers: Reopen in Container」を実行してください。
 
 ### ホストファイルのマウント

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
         # 空の場合は latest / --lts
         FNM_VERSION: ${FNM_VERSION:-}
         NODE_VERSION: ${NODE_VERSION:-}
+        # bind mount したファイルの所有をホストと一致させるため id -u / id -g を渡す
+        # 未指定時は 1000:1000 (従来挙動)。USER_UID=$(id -u) USER_GID=$(id -g) docker compose build
+        USER_UID: ${USER_UID:-1000}
+        USER_GID: ${USER_GID:-1000}
     init: true
     # コンテナ内プロセスが setuid バイナリ等で追加権限を獲得できないようにする
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,9 @@ services:
         NODE_VERSION: ${NODE_VERSION:-}
         # bind mount したファイルの所有をホストと一致させるため id -u / id -g を渡す
         # 未指定時は 1000:1000 (従来挙動)。USER_UID=$(id -u) USER_GID=$(id -g) docker compose build
+        # USER_GID は USER_UID を上書きしない限り USER_UID と同じ値にフォールバックする
         USER_UID: ${USER_UID:-1000}
-        USER_GID: ${USER_GID:-1000}
+        USER_GID: ${USER_GID:-${USER_UID:-1000}}
     init: true
     # コンテナ内プロセスが setuid バイナリ等で追加権限を獲得できないようにする
     security_opt:


### PR DESCRIPTION
Closes #116

## Summary

ホスト UID が 1000 でない環境 (macOS 501 / Linux マルチアカウント 1001+) で bind mount のファイル所有がコンテナと乖離する問題を解消。

### 変更内容 (4 ファイル, +49 / -5)

- **`docker-compose.yml`**: build args に `USER_UID` / `USER_GID` を追加 (未指定時 `1000:1000` で従来挙動)
- **`Dockerfile`**: ユーザー作成ロジックを堅牢化
  - **UID/GID 0 (root) を明示拒否** — セキュリティ事故防止
  - **既存ユーザーと UID 衝突** → `getent passwd + userdel` で動的に削除 (従来は `ubuntu` 固定だった)
  - **既存グループと GID 衝突** → `groupadd` をスキップして再利用 (例: ホスト `GID=100` の users グループ)
- **`.env.example`**: `USER_UID` / `USER_GID` のコメントエントリを追加
- **`README.md`**: Docker セクションに同期手順を追記、推奨ビルドコマンドを更新

## Test plan

ロジック単体テスト (`docker run --rm ubuntu:24.04 bash -c '...'`) で 4 ケース全成功:

| ケース | 入力 (UID:GID) | 結果 |
|--------|---------------|------|
| デフォルト (ubuntu 既存) | 1000:1000 | `uid=1000(dev) gid=1000(dev)` ✓ |
| 非デフォルト UID | 1001:1001 | `uid=1001(dev) gid=1001(dev)` ✓ |
| GID 衝突 (users=100) | 1002:100 | `uid=1002(dev) gid=100(users)` ✓ (グループ再利用) |
| 高 UID | 9999:9999 | `uid=9999(dev) gid=9999(dev)` ✓ |

compose 設定検証:
- `docker compose config` → \`USER_UID: "1000"\` (default) ✓
- `USER_UID=1234 USER_GID=5678 docker compose config` → \`USER_UID: "1234"\` ✓

### TODO

- [ ] 実環境で `USER_UID=\$(id -u) docker compose build` を流して bind mount のファイル所有を確認
- [ ] VS Code Dev Containers (Reopen in Container) でも .env から UID/GID が反映されることを確認