### PR TITLE
fix: zsh の二重ロードと autosuggestions の turbo 遅延を解消

### DIFF
--- a/dotfiles/.zsh/plugins.zsh
+++ b/dotfiles/.zsh/plugins.zsh
@@ -42,8 +42,9 @@ if [[ -n "${functions[zinit]}" ]]; then
     zinit ice ver"v1.2.0"
     zinit light Aloxaf/fzf-tab
 
-    # --- Turbo mode（遅延読み込み）---
-    # プロンプト表示後にバックグラウンドで読み込み、シェル起動を高速化
+    # --- Turbo mode（遅延読み込み）: fzf 系のみ ---
+    # プロンプト表示後にバックグラウンドで読み込み、シェル起動を高速化（即時に必要ない fzf 連携）
+    # NOTE: autosuggestions/syntax-highlighting は下部で同期ロードする（最初の行から有効化するため）
 
     # fzf キーバインディング (Ctrl-R: 履歴検索, Ctrl-T: ファイル検索, Alt-C: ディレクトリ移動)
     zinit ice wait lucid
@@ -52,11 +53,15 @@ if [[ -n "${functions[zinit]}" ]]; then
     zinit ice wait lucid
     zinit snippet "${FZF_RAW_URL}/completion.zsh"
 
-    # オートサジェスチョン (v0.7.1)
-    zinit ice wait lucid ver"v0.7.1"
+    # --- 同期読み込み（最初のプロンプトから有効化）---
+    # NOTE: autosuggestions/syntax-highlighting を turbo(wait) でロードすると、最初の
+    #       プロンプトでは ZLE フックが間に合わず効かない（Ctrl+C で再描画後に有効化される）。
+    #       最初の行から効くよう wait を外して同期ロードする。
+    # オートサジェスチョン (v0.7.1) — 同期ロード（lucid は turbo の完了通知抑制用のため付けない）
+    zinit ice ver"v0.7.1"
     zinit light zsh-users/zsh-autosuggestions
-    # シンタックスハイライト (プラグイン群の中で最後に読み込む) (0.8.0)
-    zinit ice wait lucid ver"0.8.0"
+    # シンタックスハイライト (プラグイン群の中で最後に読み込む) (0.8.0) — 同期ロード
+    zinit ice ver"0.8.0"
     zinit light zsh-users/zsh-syntax-highlighting
 else
     print -P "%F{160}Zinit が見つからない、または読み込みに失敗しました。セットアップスクリプトを確認してください。%f"

--- a/dotfiles/modules/zsh.sh
+++ b/dotfiles/modules/zsh.sh
@@ -19,15 +19,17 @@ ZSH_MOD_ZINIT_VERSION="v3.14.0"
 
 # Source separation: deploy templates to subdirectories, add source line to user dotfiles
 # NOTE: Elements are "src|user_file|deploy_dir|deploy_name|label"
+# NOTE: .zshrc は完全な設定本体のため直接配置する（下記 _zsh_direct_files）。
+#       source 分離方式だとユーザーの既存 .zshrc と二重ロードになるため。
+#       .bashrc は OS デフォルト (.bashrc) を尊重するため source 分離方式のまま。
 ZSH_MOD_SOURCE_CONFIGS=(
-    "$SCRIPT_DIR/.zshrc|$ZSH_MOD_BASE_DIR/.zshrc|$ZSH_MOD_BASE_DIR/.zshrc.d|dev-templates.zsh|.zshrc"
     "$SCRIPT_DIR/.bashrc|$HOME/.bashrc|$HOME/.bashrc.d|dev-templates.bash|.bashrc"
 )
 
 # 管理対象ファイルのリスト（配布元パス, 配置先パス, 表示名, 未検出時メッセージ）
 # NOTE: 配列の各要素は "src|dst|label|hint" の形式
 ZSH_MOD_MANAGED_FILES=(
-    "$ZSH_MOD_BASE_DIR/.zshrc.d/dev-templates.zsh|$ZSH_MOD_BASE_DIR/.zshrc.d/dev-templates.zsh|.zshrc (template)|"
+    "$SCRIPT_DIR/.zshrc|$ZSH_MOD_BASE_DIR/.zshrc|.zshrc|"
     "$HOME/.bashrc.d/dev-templates.bash|$HOME/.bashrc.d/dev-templates.bash|.bashrc (template)|"
     "$SCRIPT_DIR/.zsh/.p10k.zsh|$ZSH_MOD_CONFIG_DIR/.p10k.zsh|.p10k.zsh|Powerlevel10k のデフォルト設定が使用されます。"
     "$SCRIPT_DIR/.zsh/plugins.zsh|$ZSH_MOD_CONFIG_DIR/plugins.zsh|plugins.zsh|プラグインは手動で設定してください。"
@@ -120,6 +122,48 @@ _zsh_set_default_shell() {
     fi
 }
 
+# --- ヘルパー: 旧 source 分離方式 (.zshrc) の名残をクリーンアップ ---
+# 以前は完全な .zshrc を .zshrc.d/dev-templates.zsh として配置し、.zshrc に source
+# 行を追記していた。.zshrc を直接配置する方式へ移行したため、孤立した旧ファイルを退避する。
+# NOTE: .zshrc 本体の source 行除去は install_config による上書き配置が担う。本関数は
+#       .zshrc が dev-templates.zsh をまだ source していないことを確認してから退避するため、
+#       直接配置がスキップされた場合は何もせず環境を壊さない。
+#       必ず .zshrc の直接配置 (install_config) より後に呼ぶこと。
+_zsh_cleanup_legacy_dev_templates() {
+    local zshrc="$ZSH_MOD_BASE_DIR/.zshrc"
+    local legacy="$ZSH_MOD_BASE_DIR/.zshrc.d/dev-templates.zsh"
+
+    # 孤立した旧ファイル（通常ファイル）が無ければ何もしない。
+    # シンボリックリンクは意図的な配置の可能性があるため触らない。
+    [[ -f "$legacy" && ! -L "$legacy" ]] || return 0
+
+    # .zshrc がまだ dev-templates.zsh を source している場合、.zshrc は旧テンプレートに
+    # 依存している（直接配置がスキップされた等）。退避すると .zshrc が壊れるため触らない。
+    # source / . (ドットコマンド) の両形式を検出する。パス区切り (/) を要求して
+    # my-dev-templates.zsh のような別名ファイルへの source を誤検出しないようにする。
+    if [[ -f "$zshrc" ]] && command grep -qE '^[[:space:]]*(source|\.)[[:space:]].*/dev-templates\.zsh' "$zshrc" 2>/dev/null; then
+        msg_warn ".zshrc がまだ dev-templates.zsh を source しています。直接配置の適用後に旧ファイルが整理されます。"
+        return 0
+    fi
+
+    # 孤立した旧 dev-templates.zsh を退避する（mv の成否を検知）。
+    # 退避先は uninstall_zsh の復元対象外のため、不要なら手動削除でよい。
+    # BACKUP_SUFFIX 未定義（スタンドアロン source 等）だと dest==legacy となり mv が
+    # "same file" で失敗するため、防御的にスキップする。
+    if [[ -z "${BACKUP_SUFFIX:-}" ]]; then
+        msg_warn "BACKUP_SUFFIX が未定義のため ${legacy} の退避をスキップします。"
+        return 0
+    fi
+    local dest="${legacy}${BACKUP_SUFFIX}"
+    if ((DRY_RUN)); then
+        msg_dry_run "孤立した ${legacy} を ${dest} へ退避予定です。"
+    elif command mv "$legacy" "$dest"; then
+        msg_info "孤立した旧 dev-templates.zsh を ${dest} へ退避しました（不要なら手動削除してください）。"
+    else
+        msg_warn "${legacy} の退避に失敗しました。手動で削除してください。"
+    fi
+}
+
 # --- セットアップ ---
 setup_zsh() {
     msg_header "Zsh 設定一式"
@@ -193,14 +237,17 @@ setup_zsh() {
     # 設定ファイルの配置
     msg_info "設定ファイルを配置します..."
 
-    # Source separation: .zshrc and .bashrc deploy to subdirectories
+    # Source separation: .bashrc deploys to a subdirectory (OS デフォルトを尊重)
     for entry in "${ZSH_MOD_SOURCE_CONFIGS[@]}"; do
         IFS='|' read -r src user_file deploy_dir deploy_name label <<<"$entry"
         install_source_config "$src" "$user_file" "$deploy_dir" "$deploy_name" "$label"
     done
 
-    # Direct deployment: other config files
+    # Direct deployment: .zshrc 本体 + その他の設定ファイル
+    # NOTE: .zshrc は完全な設定本体のため直接配置する（source 分離は二重ロードの原因）。
+    #       ユーザーカスタマイズは ~/.zsh/*.zsh と ~/.shell/*.sh で受けられる。
     local _zsh_direct_files=(
+        "$SCRIPT_DIR/.zshrc|$ZSH_MOD_BASE_DIR/.zshrc|.zshrc|"
         "$SCRIPT_DIR/.zsh/.p10k.zsh|$ZSH_MOD_CONFIG_DIR/.p10k.zsh|.p10k.zsh|Powerlevel10k のデフォルト設定が使用されます。"
         "$SCRIPT_DIR/.zsh/plugins.zsh|$ZSH_MOD_CONFIG_DIR/plugins.zsh|plugins.zsh|プラグインは手動で設定してください。"
         "$SCRIPT_DIR/.shell/aliases.sh|$HOME/.shell/aliases.sh|aliases.sh|エイリアスは手動で設定してください。"
@@ -209,6 +256,10 @@ setup_zsh() {
         IFS='|' read -r src dst label hint <<<"$entry"
         install_config "$src" "$dst" "$label" "$hint"
     done
+
+    # 旧 source 分離方式の名残（孤立した dev-templates.zsh）を整理する。
+    # NOTE: .zshrc の直接配置が済んだ後に呼ぶ（順序が重要）。
+    _zsh_cleanup_legacy_dev_templates
 
     # デフォルトシェルを zsh に変更
     if ! _zsh_set_default_shell; then

--- a/dotfiles/tests/test_zsh_migration.bats
+++ b/dotfiles/tests/test_zsh_migration.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+# Tests for _zsh_cleanup_legacy_dev_templates() from modules/zsh.sh
+#
+# 旧 source 分離方式（完全な .zshrc を .zshrc.d/dev-templates.zsh として配置し、.zshrc に
+# source 行を追記する）から直接配置方式へ移行した後、孤立した旧ファイルを退避するロジック。
+# .zshrc 本体の source 行除去は install_config の上書き配置が担うため、本関数は .zshrc を
+# 編集しない。直接配置がスキップされ .zshrc がまだ source している場合は何もしない。
+#
+# NOTE: 逐語コピーではなく modules/zsh.sh を直接 source する（副作用が無く同期ずれを避ける）。
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT_DIR="$PROJECT_ROOT"
+    TEST_HOME="$(mktemp -d)"
+
+    # 依存スタブ（出力を抑制し関数ロジックのみ検証）
+    msg_info() { :; }
+    msg_warn() { :; }
+    msg_dry_run() { :; }
+    run_cmd() { "$@"; }
+    DRY_RUN=0
+    BACKUP_SUFFIX=".bak.test"
+
+    # shellcheck source=../modules/zsh.sh disable=SC1091
+    source "$PROJECT_ROOT/modules/zsh.sh"
+    # source 時に実環境値が入るためテスト用 HOME に差し替える
+    ZSH_MOD_BASE_DIR="$TEST_HOME"
+    mkdir -p "$TEST_HOME/.zshrc.d"
+}
+
+teardown() {
+    if [ -n "${TEST_HOME:-}" ]; then
+        chmod -R u+w "$TEST_HOME" 2>/dev/null || true
+        rm -rf "$TEST_HOME"
+    fi
+}
+
+@test "retires orphaned dev-templates.zsh when .zshrc does not source it" {
+    {
+        printf '%s\n' '# managed zshrc'
+        printf '%s\n' 'export FOO=1'
+    } >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    # 孤児は退避され、バックアップ(.bak.test)が残る
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh.bak.test" ]
+    # .zshrc 本体は一切触らない
+    run grep -c 'FOO=1' "$TEST_HOME/.zshrc"
+    [ "$output" -eq 1 ]
+}
+
+@test "does NOT retire dev-templates.zsh while .zshrc still sources it" {
+    {
+        printf '%s\n' '# user zshrc'
+        printf '%s\n' "source \"$TEST_HOME/.zshrc.d/dev-templates.zsh\""
+    } >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh.bak.test" ]
+}
+
+@test "does NOT retire when .zshrc sources via dot (.) form" {
+    # POSIX ドットコマンド形式の source も検出する（壊さない）
+    {
+        printf '%s\n' '# user zshrc'
+        printf '%s\n' ". \"$TEST_HOME/.zshrc.d/dev-templates.zsh\""
+    } >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}
+
+@test "is a no-op when no orphan exists" {
+    printf '# clean zshrc\n' >"$TEST_HOME/.zshrc"
+
+    run _zsh_cleanup_legacy_dev_templates
+    [ "$status" -eq 0 ]
+}
+
+@test "is idempotent (second run is a no-op)" {
+    printf '# managed zshrc\n' >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+    run _zsh_cleanup_legacy_dev_templates
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}
+
+@test "retires orphan when .zshrc only mentions dev-templates.zsh in a comment" {
+    # コメント言及のみ（source 行ではない）+ 孤児あり → コメントを誤検出せず退避する
+    {
+        printf '%s\n' '# NOTE: dev-templates.zsh は除去済み'
+        printf '%s\n' 'export KEEP=1'
+    } >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh.bak.test" ]
+    run grep -c 'KEEP' "$TEST_HOME/.zshrc"
+    [ "$output" -eq 1 ]
+}
+
+@test "skips mv and leaves file in place when DRY_RUN=1" {
+    DRY_RUN=1
+    printf '# managed zshrc\n' >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh.bak.test" ]
+}
+
+@test "warns and leaves file when mv fails" {
+    # 退避先の親が存在しないパスにして mv を確実に失敗させる（root 非依存）
+    BACKUP_SUFFIX="/no/such/dir/bak"
+    printf '# managed zshrc\n' >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+    local warned=0
+    msg_warn() { warned=1; }
+
+    _zsh_cleanup_legacy_dev_templates
+
+    # mv が失敗したので警告が出て、元ファイルは残る
+    [ "$warned" -eq 1 ]
+    [ -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}
+
+@test "retires orphan even when .zshrc does not exist" {
+    # .zshrc 未作成（直接配置がまだ走っていない状態を想定）でも安全に退避
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}
+
+@test "does NOT retire a symlinked dev-templates.zsh" {
+    # シンボリックリンクは意図的な配置の可能性があるため触らない
+    printf '# managed zshrc\n' >"$TEST_HOME/.zshrc"
+    printf '# real target\n' >"$TEST_HOME/real-template.zsh"
+    ln -s "$TEST_HOME/real-template.zsh" "$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ -L "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}
+
+@test "retires orphan when .zshrc sources a differently-named -dev-templates.zsh" {
+    # 別名ファイル(my-dev-templates.zsh)への source は本物の source とは見なさず退避する
+    {
+        printf '%s\n' '# user zshrc'
+        printf '%s\n' 'source "/some/path/my-dev-templates.zsh"'
+    } >"$TEST_HOME/.zshrc"
+    printf '# old template\n' >"$TEST_HOME/.zshrc.d/dev-templates.zsh"
+
+    _zsh_cleanup_legacy_dev_templates
+
+    [ ! -f "$TEST_HOME/.zshrc.d/dev-templates.zsh" ]
+}


### PR DESCRIPTION
## 概要

#122 の修正。zsh の二重ロードによる起動遅延と、autosuggestions / syntax-highlighting が最初のプロンプトで効かない問題を解消する。

## 根本原因

### 1. `.zshrc` の二重ロード（起動が約2倍）

`modules/zsh.sh` が **完全な `.zshrc`** を `install_source_config`（source 分離方式）で配布していた。この方式は「ユーザーの既存 dotfile を残し末尾に `source` 行を追記」するもので、`.bashrc` のように OS デフォルトがある場合は適切。しかし `.zshrc` は完全な設定本体のため、ユーザーの `~/.zshrc`（過去に直接配置された完全版）と追記された `source dev-templates.zsh` が二重実行され、`compinit` が 2 回走り起動が約 2 倍（実測 2.1 秒 → 解消後 約 1.3 秒）に膨張していた。

### 2. autosuggestions / syntax-highlighting の turbo 遅延

`plugins.zsh` が両プラグインを `zinit ice wait lucid`（turbo）で遅延ロードしており、「最初のプロンプト表示後」にロードされるため最初の行で ZLE フックが間に合わず効かず、`Ctrl+C` で再描画後に有効化されていた。

## 変更内容

### `modules/zsh.sh`
- `.zshrc` を `install_source_config`（source 分離）→ `install_config`（直接配置）へ変更。`.bashrc` は OS デフォルトを尊重するため source 分離方式のまま維持。
- `ZSH_MOD_MANAGED_FILES`（uninstall 対象）を直接配置に合わせて更新。
- 移行関数 `_zsh_migrate_legacy_zshrc_source` を追加：既存ユーザーの旧 `~/.zshrc.d/dev-templates.zsh` をバックアップ退避し、`~/.zshrc` 内の `# dev-templates managed` コメントと `dev-templates.zsh` の source 行を安全に除去（managed コメントでも source 行でもない無関係な言及は誤爆しない）。

### `.zsh/plugins.zsh`
- autosuggestions / syntax-highlighting から `wait` を除去し同期ロードに変更（fzf 系は即時必要でないため turbo のまま維持）。

### `tests/test_zsh_migration.bats`（新規）
- 移行ロジックの 4 ケース：source 行除去＋ユーザー設定保持／旧ファイルのバックアップ／クリーン時の no-op／無関係な言及の誤爆防止。

## テスト・検証

- `bats tests/`: 追加した移行テスト 4 件すべて pass、本 PR による回帰なし（`origin/main` 単体でも fail する 15 件の既存テストは skillshare / setup 実行系のローカル環境依存で、本 PR と無関係）
- `bash -n` / `shellcheck` / `shfmt`: 新規エラー・差分なし
- 移行関数の実地テスト（隔離 HOME）: source 行除去・ユーザー設定保持・バックアップを確認
- `setup.sh --dry-run --select zsh`: `.zshrc` 直接配置＋旧 `dev-templates.zsh` 移行を確認

## 補足

- nvm は既にテンプレートでは fnm（`.shell/node.sh`）へ移行済みのため対象外。

Closes #122
