### PR TITLE
feat(1password): WSL で SSH エージェントを npiperelay+socat で自動ブリッジ

### DIFF
--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -40,14 +40,44 @@ _1password_is_wsl() {
 
 if _1password_is_wsl; then
     # -------------------------------------------------
-    # WSL: Use Windows-side 1Password SSH agent
+    # WSL: Windows 側 1Password の SSH エージェントを利用する
+    #   優先: npiperelay + socat で「名前付きパイプ」を WSL の UNIX ソケットへ
+    #         ブリッジし、ネイティブ WSL の ssh / git / scp / rsync すべてを
+    #         1Password 経由にする。
+    #   退避: npiperelay/socat が無ければ ssh.exe / ssh-add.exe エイリアスへ。
+    # NOTE: このファイルは bash / zsh の双方から source されるため、
+    #       両対応の構文のみを使用する（zsh 専用の &! 等は使わない）。
     # -------------------------------------------------
-    if command -v ssh.exe >/dev/null 2>&1; then
-        alias ssh='ssh.exe'
+    _op_sock="$HOME/.1password/agent.sock"
+    _op_npiperelay="$HOME/.local/bin/npiperelay.exe"
+
+    if [[ -x "$_op_npiperelay" ]] && command -v socat >/dev/null 2>&1; then
+        # 既にブリッジ用リスナーが起動しているか確認（多重起動防止）
+        _op_running=0
+        if command -v ss >/dev/null 2>&1; then
+            ss -lx 2>/dev/null | grep -q "$_op_sock" && _op_running=1
+        elif [[ -S "$_op_sock" ]]; then
+            _op_running=1
+        fi
+
+        if [[ "$_op_running" -eq 0 ]]; then
+            mkdir -p "${_op_sock%/*}" 2>/dev/null
+            rm -f "$_op_sock" 2>/dev/null
+            # サブシェル + setsid でシェルから切り離してブリッジを常駐させる
+            ( setsid socat UNIX-LISTEN:"$_op_sock",fork EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 & ) >/dev/null 2>&1
+        fi
+        export SSH_AUTH_SOCK="$_op_sock"
+        unset _op_running
+    else
+        # フォールバック: Windows 側バイナリへ転送（対話的な ssh/ssh-add のみ）
+        if command -v ssh.exe >/dev/null 2>&1; then
+            alias ssh='ssh.exe'
+        fi
+        if command -v ssh-add.exe >/dev/null 2>&1; then
+            alias ssh-add='ssh-add.exe'
+        fi
     fi
-    if command -v ssh-add.exe >/dev/null 2>&1; then
-        alias ssh-add='ssh-add.exe'
-    fi
+    unset _op_sock _op_npiperelay
 
 elif [[ "$OSTYPE" == darwin* ]]; then
     # -------------------------------------------------

--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -64,7 +64,7 @@ if _1password_is_wsl; then
             mkdir -p "${_op_sock%/*}" 2>/dev/null
             rm -f "$_op_sock" 2>/dev/null
             # サブシェル + setsid でシェルから切り離してブリッジを常駐させる
-            ( setsid socat UNIX-LISTEN:"$_op_sock",fork EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 & ) >/dev/null 2>&1
+            (setsid socat UNIX-LISTEN:"$_op_sock",fork EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 &) >/dev/null 2>&1
         fi
         export SSH_AUTH_SOCK="$_op_sock"
         unset _op_running

--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -71,9 +71,14 @@ if _1password_is_wsl; then
             mkdir -p "${_op_sock%/*}" 2>/dev/null
             chmod 700 "${_op_sock%/*}" 2>/dev/null
             rm -f "$_op_sock" 2>/dev/null
-            # ブリッジをシェルから切り離して常駐させる。setsid があれば新セッションで
-            # 完全分離、無ければ nohup (SIGHUP 無視)、それも無ければ env (no-op) で
-            # 通常のバックグラウンド起動にフォールバックする（setsid 不在でも黙って壊れない）。
+            # ブリッジをシェルから切り離して常駐させる。SIGHUP 保護の強さは経路で異なる:
+            #   setsid: 新セッションを作成して端末から完全分離（最優先）
+            #   nohup : SIGHUP を無視して起動（フォールバック）
+            #   env   : 最後の砦。socat を直接起動するだけで追加の SIGHUP 保護は無い
+            #           （setsid/nohup の両方が無い理論上のケース。nohup は POSIX 必須
+            #            なので実環境ではほぼ到達しない。次回シェル起動時に再チェックして
+            #            起動し直すため実用上は許容）。
+            # いずれも ( ... & ) サブシェルで起動するためシェルの job list には載らない。
             # NOTE: _op_launcher は常に非空の単一語なので bash/zsh 双方で未クォート展開しても安全。
             # mode=0600 でソケットを本人のみアクセス可能にする。
             if command -v setsid >/dev/null 2>&1; then

--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -71,9 +71,20 @@ if _1password_is_wsl; then
             mkdir -p "${_op_sock%/*}" 2>/dev/null
             chmod 700 "${_op_sock%/*}" 2>/dev/null
             rm -f "$_op_sock" 2>/dev/null
-            # サブシェル + setsid でシェルから切り離してブリッジを常駐させる。
+            # ブリッジをシェルから切り離して常駐させる。setsid があれば新セッションで
+            # 完全分離、無ければ nohup (SIGHUP 無視)、それも無ければ env (no-op) で
+            # 通常のバックグラウンド起動にフォールバックする（setsid 不在でも黙って壊れない）。
+            # NOTE: _op_launcher は常に非空の単一語なので bash/zsh 双方で未クォート展開しても安全。
             # mode=0600 でソケットを本人のみアクセス可能にする。
-            (setsid socat UNIX-LISTEN:"$_op_sock",fork,mode=0600 EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 &) >/dev/null 2>&1
+            if command -v setsid >/dev/null 2>&1; then
+                _op_launcher="setsid"
+            elif command -v nohup >/dev/null 2>&1; then
+                _op_launcher="nohup"
+            else
+                _op_launcher="env"
+            fi
+            ($_op_launcher socat UNIX-LISTEN:"$_op_sock",fork,mode=0600 EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 &) >/dev/null 2>&1
+            unset _op_launcher
         fi
         export SSH_AUTH_SOCK="$_op_sock"
         unset _op_running

--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -67,8 +67,8 @@ if _1password_is_wsl; then
         fi
 
         if [[ "$_op_running" -eq 0 ]]; then
-            # 多ユーザー WSL でも他ユーザーに渡らないよう本人専用権限で作成する
-            mkdir -p -m 700 "${_op_sock%/*}" 2>/dev/null
+            # 多ユーザー WSL でも他ユーザーに渡らないよう本人専用権限にする
+            mkdir -p "${_op_sock%/*}" 2>/dev/null
             chmod 700 "${_op_sock%/*}" 2>/dev/null
             rm -f "$_op_sock" 2>/dev/null
             # サブシェル + setsid でシェルから切り離してブリッジを常駐させる。

--- a/dotfiles/.shell/1password.sh
+++ b/dotfiles/.shell/1password.sh
@@ -53,18 +53,27 @@ if _1password_is_wsl; then
 
     if [[ -x "$_op_npiperelay" ]] && command -v socat >/dev/null 2>&1; then
         # 既にブリッジ用リスナーが起動しているか確認（多重起動防止）
+        # NOTE: grep -F でソケットパス中の "." 等をメタ文字として誤マッチさせない。
         _op_running=0
         if command -v ss >/dev/null 2>&1; then
-            ss -lx 2>/dev/null | grep -q "$_op_sock" && _op_running=1
+            ss -lx 2>/dev/null | grep -qF "$_op_sock" && _op_running=1
+        elif command -v ssh-add >/dev/null 2>&1; then
+            # ss が無い環境: ソケットへ実際に接続できる (rc!=2) 場合のみ稼働中とみなす。
+            # rc=2 は接続不可 = socat が落ちてソケットだけ残った stale 状態を含む。
+            SSH_AUTH_SOCK="$_op_sock" ssh-add -l >/dev/null 2>&1
+            [[ $? -ne 2 ]] && _op_running=1
         elif [[ -S "$_op_sock" ]]; then
             _op_running=1
         fi
 
         if [[ "$_op_running" -eq 0 ]]; then
-            mkdir -p "${_op_sock%/*}" 2>/dev/null
+            # 多ユーザー WSL でも他ユーザーに渡らないよう本人専用権限で作成する
+            mkdir -p -m 700 "${_op_sock%/*}" 2>/dev/null
+            chmod 700 "${_op_sock%/*}" 2>/dev/null
             rm -f "$_op_sock" 2>/dev/null
-            # サブシェル + setsid でシェルから切り離してブリッジを常駐させる
-            (setsid socat UNIX-LISTEN:"$_op_sock",fork EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 &) >/dev/null 2>&1
+            # サブシェル + setsid でシェルから切り離してブリッジを常駐させる。
+            # mode=0600 でソケットを本人のみアクセス可能にする。
+            (setsid socat UNIX-LISTEN:"$_op_sock",fork,mode=0600 EXEC:"$_op_npiperelay -ei -s //./pipe/openssh-ssh-agent",nofork >/dev/null 2>&1 &) >/dev/null 2>&1
         fi
         export SSH_AUTH_SOCK="$_op_sock"
         unset _op_running

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -247,7 +247,8 @@ _1password_fetch_npiperelay() (
 
     # アーカイブには LICENSE/README.md 等も含まれるが、対象名 npiperelay.exe の
     # エントリのみ -j (内部パス除去) で展開し path traversal を回避する。
-    # zip 全体は SHA256 検証済みのため想定外エントリは混入しない。
+    # amd64 では zip 全体を SHA256 検証済みのため想定外エントリは混入しない
+    # (チェックサム未登録アーキは _1password_setup_npiperelay_wsl が手前でスキップする)。
     if ! unzip -o -j "$archive_path" 'npiperelay.exe' -d "$tmp_dir" >/dev/null 2>&1; then
         msg_error "npiperelay の展開に失敗しました。"
         return 1

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -196,7 +196,7 @@ _1password_ensure_wsl_deps() {
 }
 
 # --- ヘルパー: npiperelay.exe のダウンロード〜配置 (サブシェルでスコープを閉じる) ---
-# pi.sh と同じ防御方針: 一時 dir + EXIT trap、SHA256 検証、単一エントリのみ展開。
+# pi.sh と同じ防御方針: 一時 dir + EXIT trap、SHA256 検証、対象ファイルのみ展開。
 _1password_fetch_npiperelay() (
     local url="$1" asset="$2" expected_sha="$3"
 
@@ -245,7 +245,9 @@ _1password_fetch_npiperelay() (
         return 1
     fi
 
-    # npiperelay.exe のみを展開 (-j: 内部パス無視, 単一エントリ指定で path traversal を回避)
+    # アーカイブには LICENSE/README.md 等も含まれるが、対象名 npiperelay.exe の
+    # エントリのみ -j (内部パス除去) で展開し path traversal を回避する。
+    # zip 全体は SHA256 検証済みのため想定外エントリは混入しない。
     if ! unzip -o -j "$archive_path" 'npiperelay.exe' -d "$tmp_dir" >/dev/null 2>&1; then
         msg_error "npiperelay の展開に失敗しました。"
         return 1

--- a/dotfiles/modules/1password.sh
+++ b/dotfiles/modules/1password.sh
@@ -15,6 +15,18 @@ OP_MOD_DEBSIG_KEY_ID="AC2D62742012EA22"
 OP_MOD_TOKEN_DIR="${HOME}/.config/op"
 OP_MOD_TOKEN_FILE="${OP_MOD_TOKEN_DIR}/.env"
 
+# --- npiperelay (WSL SSH エージェントブリッジ用) ---
+# WSL では Windows 側 1Password の SSH エージェント (名前付きパイプ
+# //./pipe/openssh-ssh-agent) を npiperelay + socat で WSL の UNIX ソケットへ
+# ブリッジする。これによりネイティブ WSL の ssh/git/scp/rsync が 1Password を使える。
+# バージョンは固定し、ダウンロード成果物は SHA256 で検証する。
+OP_MOD_NPIPERELAY_REPO="jstarks/npiperelay"
+OP_MOD_NPIPERELAY_VERSION="v0.1.0"
+OP_MOD_NPIPERELAY_BIN_DIR="${HOME}/.local/bin"
+OP_MOD_NPIPERELAY_BIN_PATH="${OP_MOD_NPIPERELAY_BIN_DIR}/npiperelay.exe"
+# v0.1.0 amd64 アセットの SHA256 (公式 checksums.txt より)
+OP_MOD_NPIPERELAY_SHA256_AMD64="6b9ef61ffd17c03507a9a3d54d815dceb3dae669ac67fc3bf4225d1e764ce5f6"
+
 # 管理対象ファイル（配布元パス, 配置先パス, 表示名, 未検出時メッセージ）
 OP_MOD_MANAGED_FILES=(
     "$SCRIPT_DIR/.shell/1password.sh|$HOME/.shell/1password.sh|1password.sh|"
@@ -140,6 +152,164 @@ _1password_install_op_brew() {
     fi
 }
 
+# --- ヘルパー: npiperelay アセット名判定 (WSL は基本 amd64) ---
+_1password_npiperelay_asset() {
+    case "$(uname -m)" in
+    x86_64 | amd64) printf '%s' "npiperelay_windows_amd64.zip" ;;
+    *) printf '%s' "" ;;
+    esac
+}
+
+# --- ヘルパー: npiperelay アセットの期待 SHA256 ---
+_1password_npiperelay_sha256() {
+    case "$(uname -m)" in
+    x86_64 | amd64) printf '%s' "$OP_MOD_NPIPERELAY_SHA256_AMD64" ;;
+    *) printf '%s' "" ;;
+    esac
+}
+
+# --- ヘルパー: npiperelay ダウンロード URL 生成 (バージョン固定) ---
+_1password_npiperelay_url() {
+    local asset="$1"
+    printf '%s' "https://github.com/${OP_MOD_NPIPERELAY_REPO}/releases/download/${OP_MOD_NPIPERELAY_VERSION}/${asset}"
+}
+
+# --- ヘルパー: WSL ブリッジ用の依存 (curl/unzip/socat) を確保 ---
+_1password_ensure_wsl_deps() {
+    local -a missing=()
+    local cmd
+    for cmd in curl unzip socat; do
+        command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+    done
+    ((${#missing[@]} == 0)) && return 0
+
+    msg_step "WSL ブリッジ用の依存 (${missing[*]}) をインストールします..."
+    if ! command -v apt-get >/dev/null 2>&1; then
+        msg_error "apt-get が見つかりません。${missing[*]} を手動でインストールしてください。"
+        return 1
+    fi
+    run_cmd sudo apt-get update -qq || msg_warn "apt update に失敗しました。"
+    run_cmd sudo apt-get install -y "${missing[@]}" || {
+        msg_error "${missing[*]} のインストールに失敗しました。"
+        return 1
+    }
+}
+
+# --- ヘルパー: npiperelay.exe のダウンロード〜配置 (サブシェルでスコープを閉じる) ---
+# pi.sh と同じ防御方針: 一時 dir + EXIT trap、SHA256 検証、単一エントリのみ展開。
+_1password_fetch_npiperelay() (
+    local url="$1" asset="$2" expected_sha="$3"
+
+    mkdir -p "$OP_MOD_NPIPERELAY_BIN_DIR" || {
+        msg_error "${OP_MOD_NPIPERELAY_BIN_DIR} の作成に失敗しました。"
+        return 1
+    }
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d "${OP_MOD_NPIPERELAY_BIN_DIR}/.npiperelay-staging.XXXXXXXXXX") || {
+        msg_error "ステージングディレクトリの作成に失敗しました。"
+        return 1
+    }
+    # shellcheck disable=SC2064 # 即時展開で tmp_dir を埋め込む
+    trap "rm -rf -- ${tmp_dir@Q}" EXIT
+
+    local archive_path="${tmp_dir}/${asset}"
+    local curl_err="${tmp_dir}/curl.err"
+
+    if ! curl -fsSL "$url" -o "$archive_path" 2>"$curl_err"; then
+        msg_error "npiperelay のダウンロードに失敗しました。"
+        printf '  URL: %s\n' "$url" >&2
+        if [[ -s "$curl_err" ]]; then
+            printf '  curl stderr: ' >&2
+            cat "$curl_err" >&2
+        fi
+        return 1
+    fi
+
+    # SHA256 検証 (リリース侵害 / 改竄の緩和)
+    if [[ -n "$expected_sha" ]]; then
+        local actual_sha
+        actual_sha=$(sha256sum "$archive_path" 2>/dev/null | awk '{print $1}')
+        if [[ "$actual_sha" != "$expected_sha" ]]; then
+            msg_error "npiperelay のチェックサムが一致しません。中断します。"
+            printf '  expected: %s\n  actual:   %s\n' "$expected_sha" "$actual_sha" >&2
+            return 1
+        fi
+    else
+        msg_warn "このアーキテクチャ用のチェックサムが未登録です。検証なしで続行します。"
+    fi
+
+    # アーカイブに npiperelay.exe が含まれるか確認 (不一致なら unzip は非0)
+    if ! unzip -l "$archive_path" 'npiperelay.exe' >/dev/null 2>&1; then
+        msg_error "アーカイブに npiperelay.exe が含まれていません。中断します。"
+        return 1
+    fi
+
+    # npiperelay.exe のみを展開 (-j: 内部パス無視, 単一エントリ指定で path traversal を回避)
+    if ! unzip -o -j "$archive_path" 'npiperelay.exe' -d "$tmp_dir" >/dev/null 2>&1; then
+        msg_error "npiperelay の展開に失敗しました。"
+        return 1
+    fi
+
+    local extracted="${tmp_dir}/npiperelay.exe"
+    if [[ ! -f "$extracted" ]]; then
+        msg_error "展開後に npiperelay.exe が見つかりません。"
+        return 1
+    fi
+
+    chmod 0755 "$extracted" || {
+        msg_error "npiperelay.exe の権限設定に失敗しました。"
+        return 1
+    }
+
+    # 同一 FS 内の mv で atomic に配置
+    if ! mv -f "$extracted" "$OP_MOD_NPIPERELAY_BIN_PATH"; then
+        msg_error "${OP_MOD_NPIPERELAY_BIN_PATH} への配置に失敗しました。"
+        return 1
+    fi
+)
+
+# --- ヘルパー: WSL の SSH エージェントブリッジ (npiperelay + socat) をセットアップ ---
+_1password_setup_npiperelay_wsl() {
+    printf '\n'
+    printf '%s\n' "WSL SSH エージェントブリッジ (npiperelay + socat):"
+
+    local asset
+    asset=$(_1password_npiperelay_asset)
+    if [[ -z "$asset" ]]; then
+        msg_warn "未対応のアーキテクチャ ($(uname -m)) のため npiperelay 導入をスキップします。"
+        msg_step "ssh.exe エイリアスのフォールバックで動作します。"
+        return 0
+    fi
+
+    # 依存 (curl / unzip / socat) を確保
+    _1password_ensure_wsl_deps || return 1
+
+    # べき等性: 既に配置済みかつ非 UPGRADE ならスキップ
+    if [[ -f "$OP_MOD_NPIPERELAY_BIN_PATH" ]] && ! ((UPGRADE)); then
+        msg_step "npiperelay は既に配置済みです (${OP_MOD_NPIPERELAY_BIN_PATH})。スキップします。"
+        return 0
+    fi
+
+    local url sha
+    url=$(_1password_npiperelay_url "$asset")
+    sha=$(_1password_npiperelay_sha256)
+
+    msg_step "npiperelay ${OP_MOD_NPIPERELAY_VERSION} を取得します (${asset})..."
+    if ((DRY_RUN)); then
+        msg_dry_run "curl -fsSL ${url} -o <tmp>/${asset}"
+        msg_dry_run "sha256 検証 (${sha:0:12}...)"
+        msg_dry_run "unzip npiperelay.exe -> ${OP_MOD_NPIPERELAY_BIN_PATH}"
+        return 0
+    fi
+
+    if ! _1password_fetch_npiperelay "$url" "$asset" "$sha"; then
+        return 1
+    fi
+    msg_step "$(printf '%s%s%s' "${C_GREEN}" "npiperelay を配置しました: ${OP_MOD_NPIPERELAY_BIN_PATH}" "${C_RESET}")"
+    msg_step "次回シェル起動時に ~/.shell/1password.sh がブリッジを自動起動します。"
+}
+
 # --- ヘルパー: SSH エージェント設定の案内 ---
 _1password_setup_ssh_agent() {
     local env="$1"
@@ -151,7 +321,17 @@ _1password_setup_ssh_agent() {
     wsl)
         msg_step "WSL 環境を検出しました。"
         msg_step "Windows 側の 1Password デスクトップアプリで SSH エージェントを有効にしてください。"
-        msg_step "1password.zsh により ssh/ssh-add が Windows 側にリダイレクトされます。"
+        msg_step "  設定 → 開発者 → SSH エージェント → 有効にする"
+        msg_step "npiperelay + socat により Windows のエージェントが WSL の ~/.1password/agent.sock へ"
+        msg_step "ブリッジされ、ネイティブ WSL の ssh / git / scp / rsync すべてが 1Password 経由になります。"
+        msg_step "(npiperelay/socat が無い場合は ssh.exe / ssh-add.exe エイリアスにフォールバックします)"
+        printf '\n'
+        msg_step "NOTE: 1Password に鍵が多いと SSH 接続時に MaxAuthTries を超過し"
+        msg_step "      'Too many authentication failures' になることがあります。その場合は"
+        msg_step "      ~/.ssh/config でホストごとに鍵を限定してください:"
+        msg_step "        Host myhost"
+        msg_step "            IdentitiesOnly yes"
+        msg_step "            IdentityFile ~/.ssh/<対象鍵>.pub"
         printf '\n'
         msg_step "有効化:"
         msg_step "  export ENABLE_SSH_1PASSWORD=1  # ~/.zshenv 等に追加"
@@ -454,6 +634,12 @@ setup_1password() {
         install_config "$src" "$dst" "$label" "$hint"
     done
 
+    # --- 2.5. WSL: SSH エージェントブリッジ (npiperelay + socat) を導入 ---
+    if [[ "$env" == "wsl" ]]; then
+        _1password_setup_npiperelay_wsl ||
+            msg_warn "WSL ブリッジのセットアップに失敗しました（ssh.exe フォールバックで継続します）。"
+    fi
+
     # --- 3. SSH エージェント設定の案内 ---
     _1password_setup_ssh_agent "$env"
 
@@ -490,6 +676,18 @@ module_status() {
 # --- アンインストール ---
 uninstall_1password() {
     local restored=0
+
+    # WSL ブリッジ用 npiperelay.exe の削除 ($HOME 配下のみ)
+    if [[ -f "$OP_MOD_NPIPERELAY_BIN_PATH" ]]; then
+        if [[ "$OP_MOD_NPIPERELAY_BIN_PATH" == "$HOME"/* ]]; then
+            msg_info "npiperelay.exe を削除します (${OP_MOD_NPIPERELAY_BIN_PATH})..."
+            run_cmd command rm -f "$OP_MOD_NPIPERELAY_BIN_PATH" ||
+                msg_warn "${OP_MOD_NPIPERELAY_BIN_PATH} の削除に失敗しました。"
+            restored=1
+        else
+            msg_warn "${OP_MOD_NPIPERELAY_BIN_PATH} は \$HOME 配下ではないため削除をスキップします。"
+        fi
+    fi
 
     # Git 署名設定の解除
     if command -v git >/dev/null 2>&1; then
@@ -593,6 +791,9 @@ uninstall_1password() {
         msg_step "sudo apt-get remove 1password-cli"
         msg_step "sudo rm -f /etc/apt/sources.list.d/1password.list"
         msg_step "sudo rm -f /etc/apt/keyrings/1password-archive-keyring.gpg"
+        if [[ "$env" == "wsl" ]]; then
+            msg_step "socat は共有依存のため残しています (不要なら: sudo apt-get remove socat)。"
+        fi
         ;;
     macos)
         msg_step "brew uninstall --cask 1password-cli"

--- a/dotfiles/tests/test_1password_wsl.bats
+++ b/dotfiles/tests/test_1password_wsl.bats
@@ -57,6 +57,9 @@ setup() {
     OP_MOD_NPIPERELAY_BIN_DIR="$tmp_home/.local/bin"
     OP_MOD_NPIPERELAY_BIN_PATH="$OP_MOD_NPIPERELAY_BIN_DIR/npiperelay.exe"
     uname() { echo x86_64; }
+    # 依存確保 (apt 経由・run_cmd は setup.sh 側) は本テストの対象外なのでスタブ化し、
+    # 「DRY_RUN ではダウンロード・配置しない」点のみを検証する。
+    _1password_ensure_wsl_deps() { return 0; }
     DRY_RUN=1
     UPGRADE=0
 

--- a/dotfiles/tests/test_1password_wsl.bats
+++ b/dotfiles/tests/test_1password_wsl.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+# WSL 1Password SSH エージェントブリッジ (npiperelay + socat) のテスト
+# 対象: modules/1password.sh の npiperelay ヘルパー群と .shell/1password.sh の構文
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/colors.sh
+    source "$PROJECT_ROOT/lib/colors.sh"
+    # shellcheck source=../lib/array.sh
+    source "$PROJECT_ROOT/lib/array.sh"
+    _setup_colors
+    # shellcheck source=../lib/setup_helpers.sh
+    source "$PROJECT_ROOT/lib/setup_helpers.sh"
+    # shellcheck source=../modules/1password.sh
+    source "$PROJECT_ROOT/modules/1password.sh"
+}
+
+@test "npiperelay version は vX.Y.Z 形式で固定されている" {
+    [[ "$OP_MOD_NPIPERELAY_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+@test "amd64 の SHA256 定数は 64 桁の 16 進数" {
+    [[ "$OP_MOD_NPIPERELAY_SHA256_AMD64" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "x86_64 では amd64 zip アセット名を返す" {
+    uname() { echo x86_64; }
+    run _1password_npiperelay_asset
+    [ "$status" -eq 0 ]
+    [ "$output" = "npiperelay_windows_amd64.zip" ]
+}
+
+@test "x86_64 では amd64 の SHA256 を返す" {
+    uname() { echo x86_64; }
+    run _1password_npiperelay_sha256
+    [ "$output" = "$OP_MOD_NPIPERELAY_SHA256_AMD64" ]
+}
+
+@test "未対応アーキでは空のアセット名と空の SHA を返す" {
+    uname() { echo riscv64; }
+    run _1password_npiperelay_asset
+    [ -z "$output" ]
+    run _1password_npiperelay_sha256
+    [ -z "$output" ]
+}
+
+@test "URL はバージョン固定の GitHub Releases を指す" {
+    run _1password_npiperelay_url "npiperelay_windows_amd64.zip"
+    [ "$output" = "https://github.com/jstarks/npiperelay/releases/download/v0.1.0/npiperelay_windows_amd64.zip" ]
+}
+
+@test "DRY_RUN では npiperelay をダウンロード・配置しない" {
+    # 隔離した一時ディレクトリを使い実ファイルを汚さない
+    local tmp_home
+    tmp_home="$(mktemp -d)"
+    OP_MOD_NPIPERELAY_BIN_DIR="$tmp_home/.local/bin"
+    OP_MOD_NPIPERELAY_BIN_PATH="$OP_MOD_NPIPERELAY_BIN_DIR/npiperelay.exe"
+    uname() { echo x86_64; }
+    DRY_RUN=1
+    UPGRADE=0
+
+    run _1password_setup_npiperelay_wsl
+    [ "$status" -eq 0 ]
+    [ ! -e "$OP_MOD_NPIPERELAY_BIN_PATH" ]
+
+    rm -rf "$tmp_home"
+}
+
+@test ".shell/1password.sh は bash 構文として妥当" {
+    run bash -n "$PROJECT_ROOT/.shell/1password.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test ".shell/1password.sh は zsh 構文として妥当" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
+    run zsh -n "$PROJECT_ROOT/.shell/1password.sh"
+    [ "$status" -eq 0 ]
+}

--- a/dotfiles/tests/test_1password_wsl.bats
+++ b/dotfiles/tests/test_1password_wsl.bats
@@ -14,6 +14,13 @@ setup() {
     source "$PROJECT_ROOT/lib/setup_helpers.sh"
     # shellcheck source=../modules/1password.sh
     source "$PROJECT_ROOT/modules/1password.sh"
+
+    # run_cmd は本番では setup.sh が定義する。テストでは未ロードのため最小スタブを置き、
+    # 依存不足環境でも副作用 (apt 実行) なく動くようにする。
+    run_cmd() {
+        if ((${DRY_RUN:-0})); then return 0; fi
+        "$@"
+    }
 }
 
 @test "npiperelay version は vX.Y.Z 形式で固定されている" {
@@ -57,9 +64,6 @@ setup() {
     OP_MOD_NPIPERELAY_BIN_DIR="$tmp_home/.local/bin"
     OP_MOD_NPIPERELAY_BIN_PATH="$OP_MOD_NPIPERELAY_BIN_DIR/npiperelay.exe"
     uname() { echo x86_64; }
-    # 依存確保 (apt 経由・run_cmd は setup.sh 側) は本テストの対象外なのでスタブ化し、
-    # 「DRY_RUN ではダウンロード・配置しない」点のみを検証する。
-    _1password_ensure_wsl_deps() { return 0; }
     DRY_RUN=1
     UPGRADE=0
 


### PR DESCRIPTION
## 概要

WSL2 で SSH 秘密鍵を Windows 側 1Password に置く構成において、ネイティブ WSL の
`ssh` / `git` / `scp` / `rsync` を 1Password 経由で認証できるようにする。

従来の WSL 分岐は `ssh.exe` / `ssh-add.exe` エイリアスで対話的 `ssh` のみを Windows
へ転送しており、ツールが内部で呼ぶ `ssh`（git over SSH 等）は素通りして
`Permission denied (publickey)` になっていた。本 PR は Windows 側 1Password の
名前付きパイプ `//./pipe/openssh-ssh-agent` を **npiperelay + socat** で WSL の
UNIX ソケットへブリッジし、`SSH_AUTH_SOCK` を設定する方式へ切り替える。

Closes #124

## 変更点

### インストーラ `dotfiles/modules/1password.sh`
- `_1password_setup_npiperelay_wsl()` を追加。WSL 検出時のみ実行し、
  - `npiperelay.exe` を GitHub Releases から取得（**バージョン固定 `v0.1.0` + SHA256 検証**）→ `~/.local/bin/`
  - `curl` / `unzip` / `socat` を apt で確保
  - `DRY_RUN` / `UPGRADE` / べき等性に対応
  - ダウンロードは `pi.sh` と同じ防御（一時 dir + EXIT trap、単一エントリのみ展開）
- `uninstall_1password()` で `~/.local/bin/npiperelay.exe` を削除（`$HOME` 配下チェックつき）
- WSL 向け SSH エージェント案内を更新（ブリッジ方式の説明 + 鍵多数時の
  `MaxAuthTries` 超過と `IdentitiesOnly` 対処を明記）

### ランタイム `dotfiles/.shell/1password.sh`
- WSL 分岐を **ブリッジ優先・`ssh.exe` フォールバック**に変更
  - `npiperelay.exe` + `socat` があれば多重起動防止つきで socat ブリッジを起動し
    `SSH_AUTH_SOCK=~/.1password/agent.sock` を export
  - 無ければ従来の `ssh.exe` / `ssh-add.exe` エイリアス
  - bash / zsh 双方で source 可能な互換構文のみ使用

### テスト `dotfiles/tests/test_1password_wsl.bats`（新規 9 件）
- アセット名 / SHA256 定数 / URL / バージョン書式の検証
- 未対応アーキで空を返すこと
- `DRY_RUN` で副作用（ダウンロード・配置）が無いこと
- `.shell/1password.sh` の bash / zsh 構文検証

## 動作確認

- [x] `bats tests/test_1password_wsl.bats` 全 9 件パス
- [x] 既存 `test_detect_env.bats` / `test_module_metadata.bats` 回帰なし
- [x] `bash -n` / `zsh -n` / `shellcheck`（新規警告なし）
- [x] 実機 WSL で `.shell/1password.sh` を bash / zsh から source → `SSH_AUTH_SOCK`
      設定 + `ssh-add -l` が 1Password の鍵を表示
- [x] macOS / ネイティブ Linux の分岐は不変

> NOTE: 既存の `test_skillshare.bats`（13 件）は本 PR と無関係に origin/main でも
> 失敗する既存の環境起因（`/config.yaml` 権限）であり、本変更による回帰ではない。
