### PR TITLE
ci: 既存シェルスクリプトの shfmt 整形負債を一括解消

### DIFF
--- a/dotfiles/.claude/lsps-runtime/pyright/hooks/check-pyright.sh
+++ b/dotfiles/.claude/lsps-runtime/pyright/hooks/check-pyright.sh
@@ -2,16 +2,16 @@
 
 # Check if pyright-langserver is installed and available in PATH
 
-if command -v pyright-langserver &> /dev/null; then
+if command -v pyright-langserver &>/dev/null; then
     exit 0
 fi
 
 # Prefer pipx (isolated venv, avoids PEP 668 externally-managed-environment)
-if command -v pipx &> /dev/null; then
+if command -v pipx &>/dev/null; then
     echo "[pyright] Installing pyright via pipx..."
     pipx install pyright
 
-    if command -v pyright-langserver &> /dev/null; then
+    if command -v pyright-langserver &>/dev/null; then
         echo "[pyright] Installed successfully"
     else
         echo "[pyright] Failed to install. Please run manually:"
@@ -21,12 +21,12 @@ if command -v pipx &> /dev/null; then
 fi
 
 # Fallback: pip with --user (avoids system-wide install)
-if command -v pip &> /dev/null; then
+if command -v pip &>/dev/null; then
     echo "[pyright] pipx not found. Installing via pip --user..."
-    pip install --user pyright 2>&1 || \
+    pip install --user pyright 2>&1 ||
         echo "[pyright] pip install failed. Install pipx first: sudo apt install pipx"
 
-    if command -v pyright-langserver &> /dev/null; then
+    if command -v pyright-langserver &>/dev/null; then
         echo "[pyright] Installed successfully"
     else
         echo "[pyright] Failed to install. Please run manually:"

--- a/dotfiles/.claude/lsps-runtime/vtsls/hooks/check-vtsls.sh
+++ b/dotfiles/.claude/lsps-runtime/vtsls/hooks/check-vtsls.sh
@@ -2,12 +2,12 @@
 
 # Check if vtsls is installed and available in PATH
 
-if command -v vtsls &> /dev/null; then
+if command -v vtsls &>/dev/null; then
     exit 0
 fi
 
 # Check if npm is available
-if ! command -v npm &> /dev/null; then
+if ! command -v npm &>/dev/null; then
     echo "[vtsls] npm is not installed. Please install Node.js first from https://nodejs.org/"
     echo "        Then run: npm install -g @vtsls/language-server typescript"
     exit 0
@@ -17,7 +17,7 @@ fi
 echo "[vtsls] Installing vtsls..."
 npm install -g @vtsls/language-server typescript
 
-if command -v vtsls &> /dev/null; then
+if command -v vtsls &>/dev/null; then
     echo "[vtsls] Installed successfully"
 else
     echo "[vtsls] Failed to install. Please run manually:"

--- a/dotfiles/.claude/scripts/hooks/run-with-flags-shell.sh
+++ b/dotfiles/.claude/scripts/hooks/run-with-flags-shell.sh
@@ -11,22 +11,22 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
 INPUT="$(cat)"
 
 if [[ -z "$HOOK_ID" || -z "$REL_SCRIPT_PATH" ]]; then
-  printf '%s' "$INPUT"
-  exit 0
+    printf '%s' "$INPUT"
+    exit 0
 fi
 
 # Ask Node helper if this hook is enabled
 ENABLED="$(node "${PLUGIN_ROOT}/scripts/hooks/check-hook-enabled.js" "$HOOK_ID" "$PROFILES_CSV" 2>/dev/null || echo yes)"
 if [[ "$ENABLED" != "yes" ]]; then
-  printf '%s' "$INPUT"
-  exit 0
+    printf '%s' "$INPUT"
+    exit 0
 fi
 
 SCRIPT_PATH="${PLUGIN_ROOT}/${REL_SCRIPT_PATH}"
 if [[ ! -f "$SCRIPT_PATH" ]]; then
-  echo "[Hook] Script not found for ${HOOK_ID}: ${SCRIPT_PATH}" >&2
-  printf '%s' "$INPUT"
-  exit 0
+    echo "[Hook] Script not found for ${HOOK_ID}: ${SCRIPT_PATH}" >&2
+    printf '%s' "$INPUT"
+    exit 0
 fi
 
 # Extract phase prefix from hook ID (e.g., "pre:observe" -> "pre", "post:observe" -> "post")

--- a/dotfiles/.claude/scripts/orchestrate-codex-worker.sh
+++ b/dotfiles/.claude/scripts/orchestrate-codex-worker.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo "Usage: bash scripts/orchestrate-codex-worker.sh <task-file> <handoff-file> <status-file>" >&2
-  exit 1
+    echo "Usage: bash scripts/orchestrate-codex-worker.sh <task-file> <handoff-file> <status-file>" >&2
+    exit 1
 fi
 
 task_file="$1"
@@ -11,14 +11,14 @@ handoff_file="$2"
 status_file="$3"
 
 timestamp() {
-  date -u +"%Y-%m-%dT%H:%M:%SZ"
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 write_status() {
-  local state="$1"
-  local details="$2"
+    local state="$1"
+    local details="$2"
 
-  cat > "$status_file" <<EOF
+    cat >"$status_file" <<EOF
 # Status
 
 - State: $state
@@ -33,17 +33,17 @@ EOF
 mkdir -p "$(dirname "$handoff_file")" "$(dirname "$status_file")"
 
 if [[ ! -r "$task_file" ]]; then
-  write_status "failed" "- Error: task file is missing or unreadable (\`$task_file\`)"
-  {
-    echo "# Handoff"
-    echo
-    echo "- Failed: $(timestamp)"
-    echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
-    echo "- Worktree: \`$(pwd)\`"
-    echo
-    echo "Task file is missing or unreadable: \`$task_file\`"
-  } > "$handoff_file"
-  exit 1
+    write_status "failed" "- Error: task file is missing or unreadable (\`$task_file\`)"
+    {
+        echo "# Handoff"
+        echo
+        echo "- Failed: $(timestamp)"
+        echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
+        echo "- Worktree: \`$(pwd)\`"
+        echo
+        echo "Task file is missing or unreadable: \`$task_file\`"
+    } >"$handoff_file"
+    exit 1
 fi
 
 write_status "running" "- Task file: \`$task_file\`"
@@ -51,11 +51,11 @@ write_status "running" "- Task file: \`$task_file\`"
 prompt_file="$(mktemp)"
 output_file="$(mktemp)"
 cleanup() {
-  rm -f "$prompt_file" "$output_file"
+    rm -f "$prompt_file" "$output_file"
 }
 trap cleanup EXIT
 
-cat > "$prompt_file" <<EOF
+cat >"$prompt_file" <<EOF
 You are one worker in an ECC tmux/worktree swarm.
 
 Rules:
@@ -77,31 +77,31 @@ Task file: $task_file
 $(cat "$task_file")
 EOF
 
-if codex exec -p yolo -m gpt-5.4 --color never -C "$(pwd)" -o "$output_file" - < "$prompt_file"; then
-  {
-    echo "# Handoff"
-    echo
-    echo "- Completed: $(timestamp)"
-    echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
-    echo "- Worktree: \`$(pwd)\`"
-    echo
-    cat "$output_file"
-    echo
-    echo "## Git Status"
-    echo
-    git status --short
-  } > "$handoff_file"
-  write_status "completed" "- Handoff file: \`$handoff_file\`"
+if codex exec -p yolo -m gpt-5.4 --color never -C "$(pwd)" -o "$output_file" - <"$prompt_file"; then
+    {
+        echo "# Handoff"
+        echo
+        echo "- Completed: $(timestamp)"
+        echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
+        echo "- Worktree: \`$(pwd)\`"
+        echo
+        cat "$output_file"
+        echo
+        echo "## Git Status"
+        echo
+        git status --short
+    } >"$handoff_file"
+    write_status "completed" "- Handoff file: \`$handoff_file\`"
 else
-  {
-    echo "# Handoff"
-    echo
-    echo "- Failed: $(timestamp)"
-    echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
-    echo "- Worktree: \`$(pwd)\`"
-    echo
-    echo "The Codex worker exited with a non-zero status."
-  } > "$handoff_file"
-  write_status "failed" "- Handoff file: \`$handoff_file\`"
-  exit 1
+    {
+        echo "# Handoff"
+        echo
+        echo "- Failed: $(timestamp)"
+        echo "- Branch: \`$(git rev-parse --abbrev-ref HEAD)\`"
+        echo "- Worktree: \`$(pwd)\`"
+        echo
+        echo "The Codex worker exited with a non-zero status."
+    } >"$handoff_file"
+    write_status "failed" "- Handoff file: \`$handoff_file\`"
+    exit 1
 fi

--- a/dotfiles/.claude/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/dotfiles/.claude/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -19,115 +19,115 @@ SESSION_LEASE_DIR="${PROJECT_DIR}/.observer-sessions"
 ACTIVITY_FILE="${PROJECT_DIR}/.observer-last-activity"
 
 cleanup() {
-  [ -n "$SLEEP_PID" ] && kill "$SLEEP_PID" 2>/dev/null
-  if [ -f "$PID_FILE" ] && [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ]; then
-    rm -f "$PID_FILE"
-  fi
-  exit 0
+    [ -n "$SLEEP_PID" ] && kill "$SLEEP_PID" 2>/dev/null
+    if [ -f "$PID_FILE" ] && [ "$(cat "$PID_FILE" 2>/dev/null)" = "$$" ]; then
+        rm -f "$PID_FILE"
+    fi
+    exit 0
 }
 trap cleanup TERM INT
 
 file_mtime_epoch() {
-  local file="$1"
-  if [ ! -f "$file" ]; then
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        printf '0\n'
+        return
+    fi
+
+    if stat -c %Y "$file" >/dev/null 2>&1; then
+        stat -c %Y "$file" 2>/dev/null || printf '0\n'
+        return
+    fi
+
+    if stat -f %m "$file" >/dev/null 2>&1; then
+        stat -f %m "$file" 2>/dev/null || printf '0\n'
+        return
+    fi
+
     printf '0\n'
-    return
-  fi
-
-  if stat -c %Y "$file" >/dev/null 2>&1; then
-    stat -c %Y "$file" 2>/dev/null || printf '0\n'
-    return
-  fi
-
-  if stat -f %m "$file" >/dev/null 2>&1; then
-    stat -f %m "$file" 2>/dev/null || printf '0\n'
-    return
-  fi
-
-  printf '0\n'
 }
 
 has_active_session_leases() {
-  if [ ! -d "$SESSION_LEASE_DIR" ]; then
-    return 1
-  fi
+    if [ ! -d "$SESSION_LEASE_DIR" ]; then
+        return 1
+    fi
 
-  find "$SESSION_LEASE_DIR" -type f -name '*.json' -print -quit 2>/dev/null | grep -q .
+    find "$SESSION_LEASE_DIR" -type f -name '*.json' -print -quit 2>/dev/null | grep -q .
 }
 
 latest_activity_epoch() {
-  local observations_epoch activity_epoch
-  observations_epoch="$(file_mtime_epoch "$OBSERVATIONS_FILE")"
-  activity_epoch="$(file_mtime_epoch "$ACTIVITY_FILE")"
+    local observations_epoch activity_epoch
+    observations_epoch="$(file_mtime_epoch "$OBSERVATIONS_FILE")"
+    activity_epoch="$(file_mtime_epoch "$ACTIVITY_FILE")"
 
-  if [ "$activity_epoch" -gt "$observations_epoch" ] 2>/dev/null; then
-    printf '%s\n' "$activity_epoch"
-  else
-    printf '%s\n' "$observations_epoch"
-  fi
+    if [ "$activity_epoch" -gt "$observations_epoch" ] 2>/dev/null; then
+        printf '%s\n' "$activity_epoch"
+    else
+        printf '%s\n' "$observations_epoch"
+    fi
 }
 
 exit_if_idle_without_sessions() {
-  if has_active_session_leases; then
-    return
-  fi
+    if has_active_session_leases; then
+        return
+    fi
 
-  local last_activity now_epoch idle_for
-  last_activity="$(latest_activity_epoch)"
-  now_epoch="$(date +%s)"
-  idle_for=$(( now_epoch - last_activity ))
+    local last_activity now_epoch idle_for
+    last_activity="$(latest_activity_epoch)"
+    now_epoch="$(date +%s)"
+    idle_for=$((now_epoch - last_activity))
 
-  if [ "$last_activity" -eq 0 ] || [ "$idle_for" -ge "$IDLE_TIMEOUT_SECONDS" ]; then
-    echo "[$(date)] Observer idle without active session leases for ${idle_for}s; exiting" >> "$LOG_FILE"
-    cleanup
-  fi
+    if [ "$last_activity" -eq 0 ] || [ "$idle_for" -ge "$IDLE_TIMEOUT_SECONDS" ]; then
+        echo "[$(date)] Observer idle without active session leases for ${idle_for}s; exiting" >>"$LOG_FILE"
+        cleanup
+    fi
 }
 
 analyze_observations() {
-  if [ ! -f "$OBSERVATIONS_FILE" ]; then
-    return
-  fi
+    if [ ! -f "$OBSERVATIONS_FILE" ]; then
+        return
+    fi
 
-  obs_count=$(wc -l < "$OBSERVATIONS_FILE" 2>/dev/null || echo 0)
-  if [ "$obs_count" -lt "$MIN_OBSERVATIONS" ]; then
-    return
-  fi
+    obs_count=$(wc -l <"$OBSERVATIONS_FILE" 2>/dev/null || echo 0)
+    if [ "$obs_count" -lt "$MIN_OBSERVATIONS" ]; then
+        return
+    fi
 
-  echo "[$(date)] Analyzing $obs_count observations for project ${PROJECT_NAME}..." >> "$LOG_FILE"
+    echo "[$(date)] Analyzing $obs_count observations for project ${PROJECT_NAME}..." >>"$LOG_FILE"
 
-  if [ "${CLV2_IS_WINDOWS:-false}" = "true" ] && [ "${ECC_OBSERVER_ALLOW_WINDOWS:-false}" != "true" ]; then
-    echo "[$(date)] Skipping claude analysis on Windows due to known non-interactive hang issue (#295). Set ECC_OBSERVER_ALLOW_WINDOWS=true to override." >> "$LOG_FILE"
-    return
-  fi
+    if [ "${CLV2_IS_WINDOWS:-false}" = "true" ] && [ "${ECC_OBSERVER_ALLOW_WINDOWS:-false}" != "true" ]; then
+        echo "[$(date)] Skipping claude analysis on Windows due to known non-interactive hang issue (#295). Set ECC_OBSERVER_ALLOW_WINDOWS=true to override." >>"$LOG_FILE"
+        return
+    fi
 
-  if ! command -v claude >/dev/null 2>&1; then
-    echo "[$(date)] claude CLI not found, skipping analysis" >> "$LOG_FILE"
-    return
-  fi
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "[$(date)] claude CLI not found, skipping analysis" >>"$LOG_FILE"
+        return
+    fi
 
-  # session-guardian: gate observer cycle (active hours, cooldown, idle detection)
-  if ! bash "$(dirname "$0")/session-guardian.sh"; then
-    echo "[$(date)] Observer cycle skipped by session-guardian" >> "$LOG_FILE"
-    return
-  fi
+    # session-guardian: gate observer cycle (active hours, cooldown, idle detection)
+    if ! bash "$(dirname "$0")/session-guardian.sh"; then
+        echo "[$(date)] Observer cycle skipped by session-guardian" >>"$LOG_FILE"
+        return
+    fi
 
-  # Sample recent observations instead of loading the entire file (#521).
-  # This prevents multi-MB payloads from being passed to the LLM.
-  MAX_ANALYSIS_LINES="${ECC_OBSERVER_MAX_ANALYSIS_LINES:-500}"
-  observer_tmp_dir="${PROJECT_DIR}/.observer-tmp"
-  mkdir -p "$observer_tmp_dir"
-  analysis_file="$(mktemp "${observer_tmp_dir}/ecc-observer-analysis.XXXXXX.jsonl")"
-  tail -n "$MAX_ANALYSIS_LINES" "$OBSERVATIONS_FILE" > "$analysis_file"
-  analysis_count=$(wc -l < "$analysis_file" 2>/dev/null || echo 0)
-  echo "[$(date)] Using last $analysis_count of $obs_count observations for analysis" >> "$LOG_FILE"
+    # Sample recent observations instead of loading the entire file (#521).
+    # This prevents multi-MB payloads from being passed to the LLM.
+    MAX_ANALYSIS_LINES="${ECC_OBSERVER_MAX_ANALYSIS_LINES:-500}"
+    observer_tmp_dir="${PROJECT_DIR}/.observer-tmp"
+    mkdir -p "$observer_tmp_dir"
+    analysis_file="$(mktemp "${observer_tmp_dir}/ecc-observer-analysis.XXXXXX.jsonl")"
+    tail -n "$MAX_ANALYSIS_LINES" "$OBSERVATIONS_FILE" >"$analysis_file"
+    analysis_count=$(wc -l <"$analysis_file" 2>/dev/null || echo 0)
+    echo "[$(date)] Using last $analysis_count of $obs_count observations for analysis" >>"$LOG_FILE"
 
-  # Use relative path from PROJECT_DIR for cross-platform compatibility (#842).
-  # On Windows (Git Bash/MSYS2), absolute paths from mktemp may use MSYS-style
-  # prefixes (e.g. /c/Users/...) that the Claude subprocess cannot resolve.
-  analysis_relpath=".observer-tmp/$(basename "$analysis_file")"
+    # Use relative path from PROJECT_DIR for cross-platform compatibility (#842).
+    # On Windows (Git Bash/MSYS2), absolute paths from mktemp may use MSYS-style
+    # prefixes (e.g. /c/Users/...) that the Claude subprocess cannot resolve.
+    analysis_relpath=".observer-tmp/$(basename "$analysis_file")"
 
-  prompt_file="$(mktemp "${observer_tmp_dir}/ecc-observer-prompt.XXXXXX")"
-  cat > "$prompt_file" <<PROMPT
+    prompt_file="$(mktemp "${observer_tmp_dir}/ecc-observer-prompt.XXXXXX")"
+    cat >"$prompt_file" <<PROMPT
 IMPORTANT: You are running in non-interactive --print mode. You MUST use the Write tool directly to create files. Do NOT ask for permission, do NOT ask for confirmation, do NOT output summaries instead of writing. Just read, analyze, and write.
 
 Read ${analysis_relpath} and identify patterns for the project ${PROJECT_NAME} (user corrections, error resolutions, repeated workflows, tool preferences).
@@ -169,103 +169,107 @@ Rules:
 - Examples of project patterns: use React functional components, follow Django REST framework conventions
 PROMPT
 
-  timeout_seconds="${ECC_OBSERVER_TIMEOUT_SECONDS:-120}"
-  max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"
-  exit_code=0
+    timeout_seconds="${ECC_OBSERVER_TIMEOUT_SECONDS:-120}"
+    max_turns="${ECC_OBSERVER_MAX_TURNS:-20}"
+    exit_code=0
 
-  case "$max_turns" in
-    ''|*[!0-9]*)
-      max_turns=20
-      ;;
-  esac
+    case "$max_turns" in
+    '' | *[!0-9]*)
+        max_turns=20
+        ;;
+    esac
 
-  if [ "$max_turns" -lt 4 ]; then
-    max_turns=20
-  fi
-
-  # Ensure CWD is PROJECT_DIR so the relative analysis_relpath resolves correctly
-  # on all platforms, not just when the observer happens to be launched from the project root.
-  cd "$PROJECT_DIR" || { echo "[$(date)] Failed to cd to PROJECT_DIR ($PROJECT_DIR), skipping analysis" >> "$LOG_FILE"; rm -f "$prompt_file" "$analysis_file"; return; }
-
-  # Prevent observe.sh from recording this automated Haiku session as observations.
-  # Pass prompt via -p flag instead of stdin redirect for Windows compatibility (#842).
-  ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal claude --model haiku --max-turns "$max_turns" --print \
-    --allowedTools "Read,Write" \
-    -p "$(cat "$prompt_file")" >> "$LOG_FILE" 2>&1 &
-  claude_pid=$!
-  # prompt_file content was already expanded by the shell; remove early to avoid
-  # leaving stale temp files during the (potentially long) analysis window.
-  rm -f "$prompt_file"
-
-  (
-    sleep "$timeout_seconds"
-    if kill -0 "$claude_pid" 2>/dev/null; then
-      echo "[$(date)] Claude analysis timed out after ${timeout_seconds}s; terminating process" >> "$LOG_FILE"
-      kill "$claude_pid" 2>/dev/null || true
+    if [ "$max_turns" -lt 4 ]; then
+        max_turns=20
     fi
-  ) &
-  watchdog_pid=$!
 
-  wait "$claude_pid"
-  exit_code=$?
-  kill "$watchdog_pid" 2>/dev/null || true
-  rm -f "$analysis_file"
+    # Ensure CWD is PROJECT_DIR so the relative analysis_relpath resolves correctly
+    # on all platforms, not just when the observer happens to be launched from the project root.
+    cd "$PROJECT_DIR" || {
+        echo "[$(date)] Failed to cd to PROJECT_DIR ($PROJECT_DIR), skipping analysis" >>"$LOG_FILE"
+        rm -f "$prompt_file" "$analysis_file"
+        return
+    }
 
-  if [ "$exit_code" -ne 0 ]; then
-    echo "[$(date)] Claude analysis failed (exit $exit_code)" >> "$LOG_FILE"
-  fi
+    # Prevent observe.sh from recording this automated Haiku session as observations.
+    # Pass prompt via -p flag instead of stdin redirect for Windows compatibility (#842).
+    ECC_SKIP_OBSERVE=1 ECC_HOOK_PROFILE=minimal claude --model haiku --max-turns "$max_turns" --print \
+        --allowedTools "Read,Write" \
+        -p "$(cat "$prompt_file")" >>"$LOG_FILE" 2>&1 &
+    claude_pid=$!
+    # prompt_file content was already expanded by the shell; remove early to avoid
+    # leaving stale temp files during the (potentially long) analysis window.
+    rm -f "$prompt_file"
 
-  if [ -f "$OBSERVATIONS_FILE" ]; then
-    archive_dir="${PROJECT_DIR}/observations.archive"
-    mkdir -p "$archive_dir"
-    mv "$OBSERVATIONS_FILE" "$archive_dir/processed-$(date +%Y%m%d-%H%M%S)-$$.jsonl" 2>/dev/null || true
-  fi
+    (
+        sleep "$timeout_seconds"
+        if kill -0 "$claude_pid" 2>/dev/null; then
+            echo "[$(date)] Claude analysis timed out after ${timeout_seconds}s; terminating process" >>"$LOG_FILE"
+            kill "$claude_pid" 2>/dev/null || true
+        fi
+    ) &
+    watchdog_pid=$!
+
+    wait "$claude_pid"
+    exit_code=$?
+    kill "$watchdog_pid" 2>/dev/null || true
+    rm -f "$analysis_file"
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "[$(date)] Claude analysis failed (exit $exit_code)" >>"$LOG_FILE"
+    fi
+
+    if [ -f "$OBSERVATIONS_FILE" ]; then
+        archive_dir="${PROJECT_DIR}/observations.archive"
+        mkdir -p "$archive_dir"
+        mv "$OBSERVATIONS_FILE" "$archive_dir/processed-$(date +%Y%m%d-%H%M%S)-$$.jsonl" 2>/dev/null || true
+    fi
 }
 
 on_usr1() {
-  [ -n "$SLEEP_PID" ] && kill "$SLEEP_PID" 2>/dev/null
-  SLEEP_PID=""
-  USR1_FIRED=1
+    [ -n "$SLEEP_PID" ] && kill "$SLEEP_PID" 2>/dev/null
+    SLEEP_PID=""
+    USR1_FIRED=1
 
-  # Re-entrancy guard: skip if analysis is already running (#521)
-  if [ "$ANALYZING" -eq 1 ]; then
-    echo "[$(date)] Analysis already in progress, skipping signal" >> "$LOG_FILE"
-    return
-  fi
+    # Re-entrancy guard: skip if analysis is already running (#521)
+    if [ "$ANALYZING" -eq 1 ]; then
+        echo "[$(date)] Analysis already in progress, skipping signal" >>"$LOG_FILE"
+        return
+    fi
 
-  # Cooldown: skip if last analysis was too recent (#521)
-  now_epoch=$(date +%s)
-  elapsed=$(( now_epoch - LAST_ANALYSIS_EPOCH ))
-  if [ "$elapsed" -lt "$ANALYSIS_COOLDOWN" ]; then
-    echo "[$(date)] Analysis cooldown active (${elapsed}s < ${ANALYSIS_COOLDOWN}s), skipping" >> "$LOG_FILE"
-    return
-  fi
+    # Cooldown: skip if last analysis was too recent (#521)
+    now_epoch=$(date +%s)
+    elapsed=$((now_epoch - LAST_ANALYSIS_EPOCH))
+    if [ "$elapsed" -lt "$ANALYSIS_COOLDOWN" ]; then
+        echo "[$(date)] Analysis cooldown active (${elapsed}s < ${ANALYSIS_COOLDOWN}s), skipping" >>"$LOG_FILE"
+        return
+    fi
 
-  ANALYZING=1
-  analyze_observations
-  LAST_ANALYSIS_EPOCH=$(date +%s)
-  ANALYZING=0
+    ANALYZING=1
+    analyze_observations
+    LAST_ANALYSIS_EPOCH=$(date +%s)
+    ANALYZING=0
 }
 trap on_usr1 USR1
 
-echo "$$" > "$PID_FILE"
-echo "[$(date)] Observer started for ${PROJECT_NAME} (PID: $$)" >> "$LOG_FILE"
+echo "$$" >"$PID_FILE"
+echo "[$(date)] Observer started for ${PROJECT_NAME} (PID: $$)" >>"$LOG_FILE"
 
 # Prune expired pending instincts before analysis
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-"${CLV2_PYTHON_CMD:-python3}" "${SCRIPT_DIR}/../scripts/instinct-cli.py" prune --quiet >> "$LOG_FILE" 2>&1 || echo "[$(date)] Warning: instinct prune failed (non-fatal)" >> "$LOG_FILE"
+"${CLV2_PYTHON_CMD:-python3}" "${SCRIPT_DIR}/../scripts/instinct-cli.py" prune --quiet >>"$LOG_FILE" 2>&1 || echo "[$(date)] Warning: instinct prune failed (non-fatal)" >>"$LOG_FILE"
 
 while true; do
-  exit_if_idle_without_sessions
-  sleep "$OBSERVER_INTERVAL_SECONDS" &
-  SLEEP_PID=$!
-  wait "$SLEEP_PID" 2>/dev/null
-  SLEEP_PID=""
+    exit_if_idle_without_sessions
+    sleep "$OBSERVER_INTERVAL_SECONDS" &
+    SLEEP_PID=$!
+    wait "$SLEEP_PID" 2>/dev/null
+    SLEEP_PID=""
 
-  exit_if_idle_without_sessions
-  if [ "$USR1_FIRED" -eq 1 ]; then
-    USR1_FIRED=0
-  else
-    analyze_observations
-  fi
+    exit_if_idle_without_sessions
+    if [ "$USR1_FIRED" -eq 1 ]; then
+        USR1_FIRED=0
+    else
+        analyze_observations
+    fi
 done

--- a/dotfiles/.claude/skills/continuous-learning-v2/agents/session-guardian.sh
+++ b/dotfiles/.claude/skills/continuous-learning-v2/agents/session-guardian.sh
@@ -29,26 +29,26 @@ MAX_IDLE="${OBSERVER_MAX_IDLE_SECONDS:-1800}"
 # Supports overnight windows such as 2200-0600.
 # Set both ACTIVE_START and ACTIVE_END to 0 to disable this gate.
 if [ "$ACTIVE_START" -ne 0 ] || [ "$ACTIVE_END" -ne 0 ]; then
-  current_hhmm=$(date +%k%M | tr -d ' ')
-  current_hhmm_num=$(( 10#${current_hhmm:-0} ))
-  active_start_num=$(( 10#${ACTIVE_START:-800} ))
-  active_end_num=$(( 10#${ACTIVE_END:-2300} ))
+    current_hhmm=$(date +%k%M | tr -d ' ')
+    current_hhmm_num=$((10#${current_hhmm:-0}))
+    active_start_num=$((10#${ACTIVE_START:-800}))
+    active_end_num=$((10#${ACTIVE_END:-2300}))
 
-  within_active_hours=0
-  if [ "$active_start_num" -lt "$active_end_num" ]; then
-    if [ "$current_hhmm_num" -ge "$active_start_num" ] && [ "$current_hhmm_num" -lt "$active_end_num" ]; then
-      within_active_hours=1
+    within_active_hours=0
+    if [ "$active_start_num" -lt "$active_end_num" ]; then
+        if [ "$current_hhmm_num" -ge "$active_start_num" ] && [ "$current_hhmm_num" -lt "$active_end_num" ]; then
+            within_active_hours=1
+        fi
+    else
+        if [ "$current_hhmm_num" -ge "$active_start_num" ] || [ "$current_hhmm_num" -lt "$active_end_num" ]; then
+            within_active_hours=1
+        fi
     fi
-  else
-    if [ "$current_hhmm_num" -ge "$active_start_num" ] || [ "$current_hhmm_num" -lt "$active_end_num" ]; then
-      within_active_hours=1
-    fi
-  fi
 
-  if [ "$within_active_hours" -ne 1 ]; then
-    echo "session-guardian: outside active hours (${current_hhmm}, window ${ACTIVE_START}-${ACTIVE_END})" >&2
-    exit 1
-  fi
+    if [ "$within_active_hours" -ne 1 ]; then
+        echo "session-guardian: outside active hours (${current_hhmm}, window ${ACTIVE_START}-${ACTIVE_END})" >&2
+        exit 1
+    fi
 fi
 
 # ── Gate 2: Project Cooldown Log ─────────────────────────────────────────────
@@ -59,45 +59,45 @@ fi
 
 project_root="${PROJECT_DIR:-}"
 if [ -z "$project_root" ] || [ ! -d "$project_root" ]; then
-  project_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+    project_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
 fi
 project_name="$(basename "$project_root")"
 now="$(date +%s)"
 
 mkdir -p "$(dirname "$LOG_PATH")" || {
-  echo "session-guardian: cannot create log dir, proceeding" >&2
-  exit 0
+    echo "session-guardian: cannot create log dir, proceeding" >&2
+    exit 0
 }
 
 _lock_dir="${LOG_PATH}.lock"
 if ! mkdir "$_lock_dir" 2>/dev/null; then
-  # Another observer holds the lock — skip this cycle to avoid double-spawns
-  echo "session-guardian: log locked by concurrent process, skipping cycle" >&2
-  exit 1
+    # Another observer holds the lock — skip this cycle to avoid double-spawns
+    echo "session-guardian: log locked by concurrent process, skipping cycle" >&2
+    exit 1
 else
-  trap 'rm -rf "$_lock_dir"' EXIT INT TERM
+    trap 'rm -rf "$_lock_dir"' EXIT INT TERM
 
-  last_spawn=0
-  last_spawn=$(awk -F '\t' -v key="$project_root" '$1 == key { value = $2 } END { if (value != "") print value }' "$LOG_PATH" 2>/dev/null) || true
-  last_spawn="${last_spawn:-0}"
-  [[ "$last_spawn" =~ ^[0-9]+$ ]] || last_spawn=0
+    last_spawn=0
+    last_spawn=$(awk -F '\t' -v key="$project_root" '$1 == key { value = $2 } END { if (value != "") print value }' "$LOG_PATH" 2>/dev/null) || true
+    last_spawn="${last_spawn:-0}"
+    [[ "$last_spawn" =~ ^[0-9]+$ ]] || last_spawn=0
 
-  elapsed=$(( now - last_spawn ))
-  if [ "$elapsed" -lt "$INTERVAL" ]; then
+    elapsed=$((now - last_spawn))
+    if [ "$elapsed" -lt "$INTERVAL" ]; then
+        rm -rf "$_lock_dir"
+        trap - EXIT INT TERM
+        echo "session-guardian: cooldown active for '${project_name}' (last spawn ${elapsed}s ago, interval ${INTERVAL}s)" >&2
+        exit 1
+    fi
+
+    # Update log: remove old entry for this project, append new timestamp (tab-delimited)
+    tmp_log="$(mktemp "$(dirname "$LOG_PATH")/observer-last-run.XXXXXX")"
+    awk -F '\t' -v key="$project_root" '$1 != key' "$LOG_PATH" >"$tmp_log" 2>/dev/null || true
+    printf '%s\t%s\n' "$project_root" "$now" >>"$tmp_log"
+    mv "$tmp_log" "$LOG_PATH"
+
     rm -rf "$_lock_dir"
     trap - EXIT INT TERM
-    echo "session-guardian: cooldown active for '${project_name}' (last spawn ${elapsed}s ago, interval ${INTERVAL}s)" >&2
-    exit 1
-  fi
-
-  # Update log: remove old entry for this project, append new timestamp (tab-delimited)
-  tmp_log="$(mktemp "$(dirname "$LOG_PATH")/observer-last-run.XXXXXX")"
-  awk -F '\t' -v key="$project_root" '$1 != key' "$LOG_PATH" > "$tmp_log" 2>/dev/null || true
-  printf '%s\t%s\n' "$project_root" "$now" >> "$tmp_log"
-  mv "$tmp_log" "$LOG_PATH"
-
-  rm -rf "$_lock_dir"
-  trap - EXIT INT TERM
 fi
 
 # ── Gate 3: Idle Detection ────────────────────────────────────────────────────
@@ -106,45 +106,45 @@ fi
 # Set OBSERVER_MAX_IDLE_SECONDS=0 to disable this gate.
 
 get_idle_seconds() {
-  local _raw
-  case "$(uname -s)" in
+    local _raw
+    case "$(uname -s)" in
     Darwin)
-      _raw=$( { /usr/sbin/ioreg -c IOHIDSystem \
-        | /usr/bin/awk '/HIDIdleTime/ {print int($NF/1000000000); exit}'; } \
-        2>/dev/null ) || true
-      printf '%s\n' "${_raw:-0}" | head -n1
-      ;;
+        _raw=$({ /usr/sbin/ioreg -c IOHIDSystem |
+            /usr/bin/awk '/HIDIdleTime/ {print int($NF/1000000000); exit}'; } \
+            2>/dev/null) || true
+        printf '%s\n' "${_raw:-0}" | head -n1
+        ;;
     Linux)
-      if command -v xprintidle >/dev/null 2>&1; then
-        _raw=$(xprintidle 2>/dev/null) || true
-        echo $(( ${_raw:-0} / 1000 ))
-      else
-        echo 0  # fail open: xprintidle not installed
-      fi
-      ;;
-    *MINGW*|*MSYS*|*CYGWIN*)
-      _raw=$(powershell.exe -NoProfile -NonInteractive -Command \
-        "try { \
+        if command -v xprintidle >/dev/null 2>&1; then
+            _raw=$(xprintidle 2>/dev/null) || true
+            echo $((${_raw:-0} / 1000))
+        else
+            echo 0 # fail open: xprintidle not installed
+        fi
+        ;;
+    *MINGW* | *MSYS* | *CYGWIN*)
+        _raw=$(powershell.exe -NoProfile -NonInteractive -Command \
+            "try { \
           Add-Type -MemberDefinition '[DllImport(\"user32.dll\")] public static extern bool GetLastInputInfo(ref LASTINPUTINFO p); [StructLayout(LayoutKind.Sequential)] public struct LASTINPUTINFO { public uint cbSize; public int dwTime; }' -Name WinAPI -Namespace PInvoke; \
           \$l = New-Object PInvoke.WinAPI+LASTINPUTINFO; \$l.cbSize = 8; \
           [PInvoke.WinAPI]::GetLastInputInfo([ref]\$l) | Out-Null; \
           [int][Math]::Max(0, [long]([Environment]::TickCount - [long]\$l.dwTime) / 1000) \
         } catch { 0 }" \
-        2>/dev/null | tr -d '\r') || true
-      printf '%s\n' "${_raw:-0}" | head -n1
-      ;;
+            2>/dev/null | tr -d '\r') || true
+        printf '%s\n' "${_raw:-0}" | head -n1
+        ;;
     *)
-      echo 0  # fail open: unknown platform
-      ;;
-  esac
+        echo 0 # fail open: unknown platform
+        ;;
+    esac
 }
 
 if [ "$MAX_IDLE" -gt 0 ]; then
-  idle_seconds=$(get_idle_seconds)
-  if [ "$idle_seconds" -gt "$MAX_IDLE" ]; then
-    echo "session-guardian: user idle ${idle_seconds}s (threshold ${MAX_IDLE}s), skipping" >&2
-    exit 1
-  fi
+    idle_seconds=$(get_idle_seconds)
+    if [ "$idle_seconds" -gt "$MAX_IDLE" ]; then
+        echo "session-guardian: user idle ${idle_seconds}s (threshold ${MAX_IDLE}s), skipping" >&2
+        exit 1
+    fi
 fi
 
 exit 0

--- a/dotfiles/.claude/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/dotfiles/.claude/skills/continuous-learning-v2/agents/start-observer.sh
@@ -37,9 +37,9 @@ PYTHON_CMD="${CLV2_PYTHON_CMD:-}"
 
 CONFIG_DIR="${HOME}/.claude/homunculus"
 if [ -n "${CLV2_CONFIG:-}" ]; then
-  CONFIG_FILE="$CLV2_CONFIG"
+    CONFIG_FILE="$CLV2_CONFIG"
 else
-  CONFIG_FILE="${SKILL_ROOT}/config.json"
+    CONFIG_FILE="${SKILL_ROOT}/config.json"
 fi
 # PID file is project-scoped so each project can have its own observer
 PID_FILE="${PROJECT_DIR}/.observer.pid"
@@ -49,27 +49,27 @@ INSTINCTS_DIR="${PROJECT_DIR}/instincts/personal"
 SENTINEL_FILE="${CLV2_OBSERVER_SENTINEL_FILE:-${PROJECT_ROOT:-$PROJECT_DIR}/.observer.lock}"
 
 write_guard_sentinel() {
-  printf '%s\n' 'observer paused: confirmation or permission prompt detected; rerun start-observer.sh --reset after reviewing observer.log' > "$SENTINEL_FILE"
+    printf '%s\n' 'observer paused: confirmation or permission prompt detected; rerun start-observer.sh --reset after reviewing observer.log' >"$SENTINEL_FILE"
 }
 
 stop_observer_if_running() {
-  if [ -f "$PID_FILE" ]; then
-    pid=$(cat "$PID_FILE")
-    if kill -0 "$pid" 2>/dev/null; then
-      echo "Stopping observer for ${PROJECT_NAME} (PID: $pid)..."
-      kill "$pid"
-      rm -f "$PID_FILE"
-      echo "Observer stopped."
-      return 0
+    if [ -f "$PID_FILE" ]; then
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Stopping observer for ${PROJECT_NAME} (PID: $pid)..."
+            kill "$pid"
+            rm -f "$PID_FILE"
+            echo "Observer stopped."
+            return 0
+        fi
+
+        echo "Observer not running (stale PID file)."
+        rm -f "$PID_FILE"
+        return 1
     fi
 
-    echo "Observer not running (stale PID file)."
-    rm -f "$PID_FILE"
+    echo "Observer not running."
     return 1
-  fi
-
-  echo "Observer not running."
-  return 1
 }
 
 # Read config values from config.json
@@ -77,10 +77,10 @@ OBSERVER_INTERVAL_MINUTES=5
 MIN_OBSERVATIONS=20
 OBSERVER_ENABLED=false
 if [ -f "$CONFIG_FILE" ]; then
-  if [ -z "$PYTHON_CMD" ]; then
-    echo "No python interpreter found; using built-in observer defaults." >&2
-  else
-    _config=$(CLV2_CONFIG="$CONFIG_FILE" "$PYTHON_CMD" -c "
+    if [ -z "$PYTHON_CMD" ]; then
+        echo "No python interpreter found; using built-in observer defaults." >&2
+    else
+        _config=$(CLV2_CONFIG="$CONFIG_FILE" "$PYTHON_CMD" -c "
 import json, os
 with open(os.environ['CLV2_CONFIG']) as f:
     cfg = json.load(f)
@@ -91,19 +91,19 @@ print(str(obs.get('enabled', False)).lower())
 " 2>/dev/null || echo "5
 20
 false")
-    _interval=$(echo "$_config" | sed -n '1p')
-    _min_obs=$(echo "$_config" | sed -n '2p')
-    _enabled=$(echo "$_config" | sed -n '3p')
-    if [ "$_interval" -gt 0 ] 2>/dev/null; then
-      OBSERVER_INTERVAL_MINUTES="$_interval"
+        _interval=$(echo "$_config" | sed -n '1p')
+        _min_obs=$(echo "$_config" | sed -n '2p')
+        _enabled=$(echo "$_config" | sed -n '3p')
+        if [ "$_interval" -gt 0 ] 2>/dev/null; then
+            OBSERVER_INTERVAL_MINUTES="$_interval"
+        fi
+        if [ "$_min_obs" -gt 0 ] 2>/dev/null; then
+            MIN_OBSERVATIONS="$_min_obs"
+        fi
+        if [ "$_enabled" = "true" ]; then
+            OBSERVER_ENABLED=true
+        fi
     fi
-    if [ "$_min_obs" -gt 0 ] 2>/dev/null; then
-      MIN_OBSERVATIONS="$_min_obs"
-    fi
-    if [ "$_enabled" = "true" ]; then
-      OBSERVER_ENABLED=true
-    fi
-  fi
 fi
 OBSERVER_INTERVAL_SECONDS=$((OBSERVER_INTERVAL_MINUTES * 60))
 
@@ -114,130 +114,130 @@ echo "Storage: ${PROJECT_DIR}"
 UNAME_LOWER="$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')"
 IS_WINDOWS=false
 case "$UNAME_LOWER" in
-  *mingw*|*msys*|*cygwin*) IS_WINDOWS=true ;;
+*mingw* | *msys* | *cygwin*) IS_WINDOWS=true ;;
 esac
 
 ACTION="start"
 RESET_OBSERVER=false
 
 for arg in "$@"; do
-  case "$arg" in
-    start|stop|status)
-      ACTION="$arg"
-      ;;
+    case "$arg" in
+    start | stop | status)
+        ACTION="$arg"
+        ;;
     --reset)
-      RESET_OBSERVER=true
-      ;;
+        RESET_OBSERVER=true
+        ;;
     *)
-      echo "Usage: $0 [start|stop|status] [--reset]"
-      exit 1
-      ;;
-  esac
+        echo "Usage: $0 [start|stop|status] [--reset]"
+        exit 1
+        ;;
+    esac
 done
 
 if [ "$RESET_OBSERVER" = "true" ]; then
-  rm -f "$SENTINEL_FILE"
+    rm -f "$SENTINEL_FILE"
 fi
 
 case "$ACTION" in
-  stop)
+stop)
     stop_observer_if_running || true
     exit 0
     ;;
 
-  status)
+status)
     if [ -f "$PID_FILE" ]; then
-      pid=$(cat "$PID_FILE")
-      if kill -0 "$pid" 2>/dev/null; then
-        echo "Observer is running (PID: $pid)"
-        echo "Log: $LOG_FILE"
-        echo "Observations: $(wc -l < "$OBSERVATIONS_FILE" 2>/dev/null || echo 0) lines"
-        # Also show instinct count
-        instinct_count=$(find "$INSTINCTS_DIR" -name "*.yaml" 2>/dev/null | wc -l)
-        echo "Instincts: $instinct_count"
-        exit 0
-      else
-        echo "Observer not running (stale PID file)"
-        rm -f "$PID_FILE"
-        exit 1
-      fi
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Observer is running (PID: $pid)"
+            echo "Log: $LOG_FILE"
+            echo "Observations: $(wc -l <"$OBSERVATIONS_FILE" 2>/dev/null || echo 0) lines"
+            # Also show instinct count
+            instinct_count=$(find "$INSTINCTS_DIR" -name "*.yaml" 2>/dev/null | wc -l)
+            echo "Instincts: $instinct_count"
+            exit 0
+        else
+            echo "Observer not running (stale PID file)"
+            rm -f "$PID_FILE"
+            exit 1
+        fi
     else
-      echo "Observer not running"
-      exit 1
+        echo "Observer not running"
+        exit 1
     fi
     ;;
 
-  start)
+start)
     # Check if observer is disabled in config
     if [ "$OBSERVER_ENABLED" != "true" ]; then
-      echo "Observer is disabled in config.json (observer.enabled: false)."
-      echo "Set observer.enabled to true in config.json to enable."
-      exit 1
+        echo "Observer is disabled in config.json (observer.enabled: false)."
+        echo "Set observer.enabled to true in config.json to enable."
+        exit 1
     fi
 
     # Check if already running
     if [ -f "$PID_FILE" ]; then
-      pid=$(cat "$PID_FILE")
-      if kill -0 "$pid" 2>/dev/null; then
-        echo "Observer already running for ${PROJECT_NAME} (PID: $pid)"
-        exit 0
-      fi
-      rm -f "$PID_FILE"
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Observer already running for ${PROJECT_NAME} (PID: $pid)"
+            exit 0
+        fi
+        rm -f "$PID_FILE"
     fi
 
     echo "Starting observer agent for ${PROJECT_NAME}..."
 
     if [ ! -x "$OBSERVER_LOOP_SCRIPT" ]; then
-      echo "Observer loop script not found or not executable: $OBSERVER_LOOP_SCRIPT"
-      exit 1
+        echo "Observer loop script not found or not executable: $OBSERVER_LOOP_SCRIPT"
+        exit 1
     fi
 
     mkdir -p "$PROJECT_DIR"
     touch "$LOG_FILE"
-    start_line=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+    start_line=$(wc -l <"$LOG_FILE" 2>/dev/null || echo 0)
 
     nohup env \
-      CONFIG_DIR="$CONFIG_DIR" \
-      PID_FILE="$PID_FILE" \
-      LOG_FILE="$LOG_FILE" \
-      OBSERVATIONS_FILE="$OBSERVATIONS_FILE" \
-      INSTINCTS_DIR="$INSTINCTS_DIR" \
-      PROJECT_DIR="$PROJECT_DIR" \
-      PROJECT_NAME="$PROJECT_NAME" \
-      PROJECT_ID="$PROJECT_ID" \
-      MIN_OBSERVATIONS="$MIN_OBSERVATIONS" \
-      OBSERVER_INTERVAL_SECONDS="$OBSERVER_INTERVAL_SECONDS" \
-      CLV2_IS_WINDOWS="$IS_WINDOWS" \
-      CLV2_OBSERVER_PROMPT_PATTERN="$CLV2_OBSERVER_PROMPT_PATTERN" \
-      "$OBSERVER_LOOP_SCRIPT" >> "$LOG_FILE" 2>&1 &
+        CONFIG_DIR="$CONFIG_DIR" \
+        PID_FILE="$PID_FILE" \
+        LOG_FILE="$LOG_FILE" \
+        OBSERVATIONS_FILE="$OBSERVATIONS_FILE" \
+        INSTINCTS_DIR="$INSTINCTS_DIR" \
+        PROJECT_DIR="$PROJECT_DIR" \
+        PROJECT_NAME="$PROJECT_NAME" \
+        PROJECT_ID="$PROJECT_ID" \
+        MIN_OBSERVATIONS="$MIN_OBSERVATIONS" \
+        OBSERVER_INTERVAL_SECONDS="$OBSERVER_INTERVAL_SECONDS" \
+        CLV2_IS_WINDOWS="$IS_WINDOWS" \
+        CLV2_OBSERVER_PROMPT_PATTERN="$CLV2_OBSERVER_PROMPT_PATTERN" \
+        "$OBSERVER_LOOP_SCRIPT" >>"$LOG_FILE" 2>&1 &
 
     # Wait for PID file
     sleep 2
 
     # Check for confirmation-seeking output in the observer log
     if tail -n +"$((start_line + 1))" "$LOG_FILE" 2>/dev/null | grep -E -i -q "$CLV2_OBSERVER_PROMPT_PATTERN"; then
-      echo "OBSERVER_ABORT: Confirmation or permission prompt detected in observer output. Failing closed."
-      stop_observer_if_running >/dev/null 2>&1 || true
-      write_guard_sentinel
-      exit 2
+        echo "OBSERVER_ABORT: Confirmation or permission prompt detected in observer output. Failing closed."
+        stop_observer_if_running >/dev/null 2>&1 || true
+        write_guard_sentinel
+        exit 2
     fi
 
     if [ -f "$PID_FILE" ]; then
-      pid=$(cat "$PID_FILE")
-      if kill -0 "$pid" 2>/dev/null; then
-        echo "Observer started (PID: $pid)"
-        echo "Log: $LOG_FILE"
-      else
-        echo "Failed to start observer (process died immediately, check $LOG_FILE)"
-        exit 1
-      fi
+        pid=$(cat "$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Observer started (PID: $pid)"
+            echo "Log: $LOG_FILE"
+        else
+            echo "Failed to start observer (process died immediately, check $LOG_FILE)"
+            exit 1
+        fi
     else
-      echo "Failed to start observer"
-      exit 1
+        echo "Failed to start observer"
+        exit 1
     fi
     ;;
 
-  *)
+*)
     echo "Usage: $0 [start|stop|status] [--reset]"
     exit 1
     ;;

--- a/dotfiles/.claude/skills/continuous-learning-v2/hooks/observe.sh
+++ b/dotfiles/.claude/skills/continuous-learning-v2/hooks/observe.sh
@@ -24,32 +24,32 @@ INPUT_JSON=$(cat)
 
 # Exit if no input
 if [ -z "$INPUT_JSON" ]; then
-  exit 0
+    exit 0
 fi
 
 resolve_python_cmd() {
-  if [ -n "${CLV2_PYTHON_CMD:-}" ] && command -v "$CLV2_PYTHON_CMD" >/dev/null 2>&1; then
-    printf '%s\n' "$CLV2_PYTHON_CMD"
-    return 0
-  fi
+    if [ -n "${CLV2_PYTHON_CMD:-}" ] && command -v "$CLV2_PYTHON_CMD" >/dev/null 2>&1; then
+        printf '%s\n' "$CLV2_PYTHON_CMD"
+        return 0
+    fi
 
-  if command -v python3 >/dev/null 2>&1; then
-    printf '%s\n' python3
-    return 0
-  fi
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' python3
+        return 0
+    fi
 
-  if command -v python >/dev/null 2>&1; then
-    printf '%s\n' python
-    return 0
-  fi
+    if command -v python >/dev/null 2>&1; then
+        printf '%s\n' python
+        return 0
+    fi
 
-  return 1
+    return 1
 }
 
 PYTHON_CMD="$(resolve_python_cmd 2>/dev/null || true)"
 if [ -z "$PYTHON_CMD" ]; then
-  echo "[observe] No python interpreter found, skipping observation" >&2
-  exit 0
+    echo "[observe] No python interpreter found, skipping observation" >&2
+    exit 0
 fi
 
 # ─────────────────────────────────────────────
@@ -71,8 +71,8 @@ except(KeyError, TypeError, ValueError):
 
 # If cwd was provided in stdin, use it for project detection
 if [ -n "$STDIN_CWD" ] && [ -d "$STDIN_CWD" ]; then
-  _GIT_ROOT=$(git -C "$STDIN_CWD" rev-parse --show-toplevel 2>/dev/null || true)
-  export CLAUDE_PROJECT_DIR="${_GIT_ROOT:-$STDIN_CWD}"
+    _GIT_ROOT=$(git -C "$STDIN_CWD" rev-parse --show-toplevel 2>/dev/null || true)
+    export CLAUDE_PROJECT_DIR="${_GIT_ROOT:-$STDIN_CWD}"
 fi
 
 # ─────────────────────────────────────────────
@@ -87,10 +87,10 @@ CONFIG_DIR="${HOME}/.claude/homunculus"
 
 # Skip if disabled (check both default and CLV2_CONFIG-derived locations)
 if [ -f "$CONFIG_DIR/disabled" ]; then
-  exit 0
+    exit 0
 fi
 if [ -n "${CLV2_CONFIG:-}" ] && [ -f "$(dirname "$CLV2_CONFIG")/disabled" ]; then
-  exit 0
+    exit 0
 fi
 
 # Prevent observe.sh from firing on non-human sessions to avoid:
@@ -103,8 +103,8 @@ fi
 # Non-interactive SDK automation is still filtered by Layers 2-5 below
 # (ECC_HOOK_PROFILE=minimal, ECC_SKIP_OBSERVE=1, agent_id, path exclusions).
 case "${CLAUDE_CODE_ENTRYPOINT:-cli}" in
-  cli|sdk-ts) ;;
-  *) exit 0 ;;
+cli | sdk-ts) ;;
+*) exit 0 ;;
 esac
 
 # Layer 2: minimal hook profile suppresses non-essential hooks.
@@ -120,13 +120,13 @@ _ECC_AGENT_ID=$(echo "$INPUT_JSON" | "$PYTHON_CMD" -c "import json,sys; print(js
 # Layer 5: known observer-session path exclusions.
 _ECC_SKIP_PATHS="${ECC_OBSERVE_SKIP_PATHS:-observer-sessions,.claude-mem}"
 if [ -n "$STDIN_CWD" ]; then
-  IFS=',' read -ra _ECC_SKIP_ARRAY <<< "$_ECC_SKIP_PATHS"
-  for _pattern in "${_ECC_SKIP_ARRAY[@]}"; do
-    _pattern="${_pattern#"${_pattern%%[![:space:]]*}"}"
-    _pattern="${_pattern%"${_pattern##*[![:space:]]}"}"
-    [ -z "$_pattern" ] && continue
-    case "$STDIN_CWD" in *"$_pattern"*) exit 0 ;; esac
-  done
+    IFS=',' read -ra _ECC_SKIP_ARRAY <<<"$_ECC_SKIP_PATHS"
+    for _pattern in "${_ECC_SKIP_ARRAY[@]}"; do
+        _pattern="${_pattern#"${_pattern%%[![:space:]]*}"}"
+        _pattern="${_pattern%"${_pattern##*[![:space:]]}"}"
+        [ -z "$_pattern" ] && continue
+        case "$STDIN_CWD" in *"$_pattern"*) exit 0 ;; esac
+    done
 fi
 
 # ─────────────────────────────────────────────
@@ -151,8 +151,8 @@ MAX_FILE_SIZE_MB=10
 # Auto-purge observation files older than 30 days (runs once per session)
 PURGE_MARKER="${PROJECT_DIR}/.last-purge"
 if [ ! -f "$PURGE_MARKER" ] || [ "$(find "$PURGE_MARKER" -mtime +1 2>/dev/null)" ]; then
-  find "${PROJECT_DIR}" -name "observations-*.jsonl" -mtime +30 -delete 2>/dev/null || true
-  touch "$PURGE_MARKER" 2>/dev/null || true
+    find "${PROJECT_DIR}" -name "observations-*.jsonl" -mtime +30 -delete 2>/dev/null || true
+    touch "$PURGE_MARKER" 2>/dev/null || true
 fi
 
 # Parse using Python via stdin pipe (safe for all JSON payloads)
@@ -210,10 +210,10 @@ except Exception as e:
 PARSED_OK=$(echo "$PARSED" | "$PYTHON_CMD" -c "import json,sys; print(json.load(sys.stdin).get('parsed', False))" 2>/dev/null || echo "False")
 
 if [ "$PARSED_OK" != "True" ]; then
-  # Fallback: log raw input for debugging (scrub secrets before persisting)
-  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  export TIMESTAMP="$timestamp"
-  echo "$INPUT_JSON" | "$PYTHON_CMD" -c '
+    # Fallback: log raw input for debugging (scrub secrets before persisting)
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    export TIMESTAMP="$timestamp"
+    echo "$INPUT_JSON" | "$PYTHON_CMD" -c '
 import json, sys, os, re
 
 _SECRET_RE = re.compile(
@@ -226,18 +226,18 @@ _SECRET_RE = re.compile(
 raw = sys.stdin.read()[:2000]
 raw = _SECRET_RE.sub(lambda m: m.group(1) + m.group(2) + (m.group(3) or "") + "[REDACTED]", raw)
 print(json.dumps({"timestamp": os.environ["TIMESTAMP"], "event": "parse_error", "raw": raw}))
-' >> "$OBSERVATIONS_FILE"
-  exit 0
+' >>"$OBSERVATIONS_FILE"
+    exit 0
 fi
 
 # Archive if file too large (atomic: rename with unique suffix to avoid race)
 if [ -f "$OBSERVATIONS_FILE" ]; then
-  file_size_mb=$(du -m "$OBSERVATIONS_FILE" 2>/dev/null | cut -f1)
-  if [ "${file_size_mb:-0}" -ge "$MAX_FILE_SIZE_MB" ]; then
-    archive_dir="${PROJECT_DIR}/observations.archive"
-    mkdir -p "$archive_dir"
-    mv "$OBSERVATIONS_FILE" "$archive_dir/observations-$(date +%Y%m%d-%H%M%S)-$$.jsonl" 2>/dev/null || true
-  fi
+    file_size_mb=$(du -m "$OBSERVATIONS_FILE" 2>/dev/null | cut -f1)
+    if [ "${file_size_mb:-0}" -ge "$MAX_FILE_SIZE_MB" ]; then
+        archive_dir="${PROJECT_DIR}/observations.archive"
+        mkdir -p "$archive_dir"
+        mv "$OBSERVATIONS_FILE" "$archive_dir/observations-$(date +%Y%m%d-%H%M%S)-$$.jsonl" 2>/dev/null || true
+    fi
 fi
 
 # Build and write observation (now includes project context)
@@ -281,104 +281,104 @@ if parsed["output"] is not None:
     observation["output"] = scrub(parsed["output"])
 
 print(json.dumps(observation))
-' >> "$OBSERVATIONS_FILE"
+' >>"$OBSERVATIONS_FILE"
 
 # Lazy-start observer if enabled but not running (first-time setup)
 # Use flock for atomic check-then-act to prevent race conditions
 # Fallback for macOS (no flock): use lockfile or skip
 LAZY_START_LOCK="${PROJECT_DIR}/.observer-start.lock"
 _CHECK_OBSERVER_RUNNING() {
-  local pid_file="$1"
-  if [ -f "$pid_file" ]; then
-    local pid
-    pid=$(cat "$pid_file" 2>/dev/null)
-    # Validate PID is a positive integer (>1) to prevent signaling invalid targets
-    case "$pid" in
-      ''|*[!0-9]*|0|1)
+    local pid_file="$1"
+    if [ -f "$pid_file" ]; then
+        local pid
+        pid=$(cat "$pid_file" 2>/dev/null)
+        # Validate PID is a positive integer (>1) to prevent signaling invalid targets
+        case "$pid" in
+        '' | *[!0-9]* | 0 | 1)
+            rm -f "$pid_file" 2>/dev/null || true
+            return 1
+            ;;
+        esac
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0 # Process is alive
+        fi
+        # Stale PID file - remove it
         rm -f "$pid_file" 2>/dev/null || true
-        return 1
-        ;;
-    esac
-    if kill -0 "$pid" 2>/dev/null; then
-      return 0  # Process is alive
     fi
-    # Stale PID file - remove it
-    rm -f "$pid_file" 2>/dev/null || true
-  fi
-  return 1  # No PID file or process dead
+    return 1 # No PID file or process dead
 }
 
 if [ -f "${CONFIG_DIR}/disabled" ]; then
-  OBSERVER_ENABLED=false
+    OBSERVER_ENABLED=false
 else
-  OBSERVER_ENABLED=false
-  CONFIG_FILE="${SKILL_ROOT}/config.json"
-  # Allow CLV2_CONFIG override
-  if [ -n "${CLV2_CONFIG:-}" ]; then
-    CONFIG_FILE="$CLV2_CONFIG"
-  fi
-  # Use effective config path for both existence check and reading
-  EFFECTIVE_CONFIG="$CONFIG_FILE"
-  if [ -f "$EFFECTIVE_CONFIG" ] && [ -n "$PYTHON_CMD" ]; then
-    _enabled=$(CLV2_CONFIG_PATH="$EFFECTIVE_CONFIG" "$PYTHON_CMD" -c "
+    OBSERVER_ENABLED=false
+    CONFIG_FILE="${SKILL_ROOT}/config.json"
+    # Allow CLV2_CONFIG override
+    if [ -n "${CLV2_CONFIG:-}" ]; then
+        CONFIG_FILE="$CLV2_CONFIG"
+    fi
+    # Use effective config path for both existence check and reading
+    EFFECTIVE_CONFIG="$CONFIG_FILE"
+    if [ -f "$EFFECTIVE_CONFIG" ] && [ -n "$PYTHON_CMD" ]; then
+        _enabled=$(CLV2_CONFIG_PATH="$EFFECTIVE_CONFIG" "$PYTHON_CMD" -c "
 import json, os
 with open(os.environ['CLV2_CONFIG_PATH']) as f:
     cfg = json.load(f)
 print(str(cfg.get('observer', {}).get('enabled', False)).lower())
 " 2>/dev/null || echo "false")
-    if [ "$_enabled" = "true" ]; then
-      OBSERVER_ENABLED=true
+        if [ "$_enabled" = "true" ]; then
+            OBSERVER_ENABLED=true
+        fi
     fi
-  fi
 fi
 
 # Check both project-scoped AND global PID files (with stale PID recovery)
 if [ "$OBSERVER_ENABLED" = "true" ]; then
-  # Clean up stale PID files first
-  _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-  _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
+    # Clean up stale PID files first
+    _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
+    _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
 
-  # Check if observer is now running after cleanup
-  if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
-    # Use flock if available (Linux), fallback for macOS
-    if command -v flock >/dev/null 2>&1; then
-      (
-        flock -n 9 || exit 0
-        # Double-check PID files after acquiring lock
-        _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-        _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-        if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
-          nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
+    # Check if observer is now running after cleanup
+    if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+        # Use flock if available (Linux), fallback for macOS
+        if command -v flock >/dev/null 2>&1; then
+            (
+                flock -n 9 || exit 0
+                # Double-check PID files after acquiring lock
+                _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
+                _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
+                if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+                    nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
+                fi
+            ) 9>"$LAZY_START_LOCK"
+        else
+            # macOS fallback: use lockfile if available, otherwise mkdir-based lock
+            if command -v lockfile >/dev/null 2>&1; then
+                # Use subshell to isolate exit and add trap for cleanup
+                (
+                    trap 'rm -f "$LAZY_START_LOCK" 2>/dev/null || true' EXIT
+                    lockfile -r 1 -l 30 "$LAZY_START_LOCK" 2>/dev/null || exit 0
+                    _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
+                    _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
+                    if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+                        nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
+                    fi
+                    rm -f "$LAZY_START_LOCK" 2>/dev/null || true
+                )
+            else
+                # POSIX fallback: mkdir is atomic -- fails if dir already exists
+                (
+                    trap 'rmdir "${LAZY_START_LOCK}.d" 2>/dev/null || true' EXIT
+                    mkdir "${LAZY_START_LOCK}.d" 2>/dev/null || exit 0
+                    _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
+                    _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
+                    if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
+                        nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
+                    fi
+                )
+            fi
         fi
-      ) 9>"$LAZY_START_LOCK"
-    else
-      # macOS fallback: use lockfile if available, otherwise mkdir-based lock
-      if command -v lockfile >/dev/null 2>&1; then
-        # Use subshell to isolate exit and add trap for cleanup
-        (
-          trap 'rm -f "$LAZY_START_LOCK" 2>/dev/null || true' EXIT
-          lockfile -r 1 -l 30 "$LAZY_START_LOCK" 2>/dev/null || exit 0
-          _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-          _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-          if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
-            nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
-          fi
-          rm -f "$LAZY_START_LOCK" 2>/dev/null || true
-        )
-      else
-        # POSIX fallback: mkdir is atomic -- fails if dir already exists
-        (
-          trap 'rmdir "${LAZY_START_LOCK}.d" 2>/dev/null || true' EXIT
-          mkdir "${LAZY_START_LOCK}.d" 2>/dev/null || exit 0
-          _CHECK_OBSERVER_RUNNING "${PROJECT_DIR}/.observer.pid" || true
-          _CHECK_OBSERVER_RUNNING "${CONFIG_DIR}/.observer.pid" || true
-          if [ ! -f "${PROJECT_DIR}/.observer.pid" ] && [ ! -f "${CONFIG_DIR}/.observer.pid" ]; then
-            nohup "${SKILL_ROOT}/agents/start-observer.sh" start >/dev/null 2>&1 &
-          fi
-        )
-      fi
     fi
-  fi
 fi
 
 # Throttle SIGUSR1: only signal observer every N observations (#521)
@@ -392,37 +392,40 @@ touch "$ACTIVITY_FILE" 2>/dev/null || true
 
 should_signal=0
 if [ -f "$SIGNAL_COUNTER_FILE" ]; then
-  counter=$(cat "$SIGNAL_COUNTER_FILE" 2>/dev/null || echo 0)
-  counter=$((counter + 1))
-  if [ "$counter" -ge "$SIGNAL_EVERY_N" ]; then
-    should_signal=1
-    counter=0
-  fi
-  echo "$counter" > "$SIGNAL_COUNTER_FILE"
+    counter=$(cat "$SIGNAL_COUNTER_FILE" 2>/dev/null || echo 0)
+    counter=$((counter + 1))
+    if [ "$counter" -ge "$SIGNAL_EVERY_N" ]; then
+        should_signal=1
+        counter=0
+    fi
+    echo "$counter" >"$SIGNAL_COUNTER_FILE"
 else
-  echo "1" > "$SIGNAL_COUNTER_FILE"
+    echo "1" >"$SIGNAL_COUNTER_FILE"
 fi
 
 # Signal observer if running and throttle allows (check both project-scoped and global observer, deduplicate)
 if [ "$should_signal" -eq 1 ]; then
-  signaled_pids=" "
-  for pid_file in "${PROJECT_DIR}/.observer.pid" "${CONFIG_DIR}/.observer.pid"; do
-    if [ -f "$pid_file" ]; then
-      observer_pid=$(cat "$pid_file" 2>/dev/null || true)
-      # Validate PID is a positive integer (>1)
-      case "$observer_pid" in
-        ''|*[!0-9]*|0|1) rm -f "$pid_file" 2>/dev/null || true; continue ;;
-      esac
-      # Deduplicate: skip if already signaled this pass
-      case "$signaled_pids" in
-        *" $observer_pid "*) continue ;;
-      esac
-      if kill -0 "$observer_pid" 2>/dev/null; then
-        kill -USR1 "$observer_pid" 2>/dev/null || true
-        signaled_pids="${signaled_pids}${observer_pid} "
-      fi
-    fi
-  done
+    signaled_pids=" "
+    for pid_file in "${PROJECT_DIR}/.observer.pid" "${CONFIG_DIR}/.observer.pid"; do
+        if [ -f "$pid_file" ]; then
+            observer_pid=$(cat "$pid_file" 2>/dev/null || true)
+            # Validate PID is a positive integer (>1)
+            case "$observer_pid" in
+            '' | *[!0-9]* | 0 | 1)
+                rm -f "$pid_file" 2>/dev/null || true
+                continue
+                ;;
+            esac
+            # Deduplicate: skip if already signaled this pass
+            case "$signaled_pids" in
+            *" $observer_pid "*) continue ;;
+            esac
+            if kill -0 "$observer_pid" 2>/dev/null; then
+                kill -USR1 "$observer_pid" 2>/dev/null || true
+                signaled_pids="${signaled_pids}${observer_pid} "
+            fi
+        fi
+    done
 fi
 
 exit 0

--- a/dotfiles/.claude/skills/continuous-learning-v2/scripts/detect-project.sh
+++ b/dotfiles/.claude/skills/continuous-learning-v2/scripts/detect-project.sh
@@ -24,22 +24,22 @@ _CLV2_PROJECTS_DIR="${_CLV2_HOMUNCULUS_DIR}/projects"
 _CLV2_REGISTRY_FILE="${_CLV2_HOMUNCULUS_DIR}/projects.json"
 
 _clv2_resolve_python_cmd() {
-  if [ -n "${CLV2_PYTHON_CMD:-}" ] && command -v "$CLV2_PYTHON_CMD" >/dev/null 2>&1; then
-    printf '%s\n' "$CLV2_PYTHON_CMD"
-    return 0
-  fi
+    if [ -n "${CLV2_PYTHON_CMD:-}" ] && command -v "$CLV2_PYTHON_CMD" >/dev/null 2>&1; then
+        printf '%s\n' "$CLV2_PYTHON_CMD"
+        return 0
+    fi
 
-  if command -v python3 >/dev/null 2>&1; then
-    printf '%s\n' python3
-    return 0
-  fi
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' python3
+        return 0
+    fi
 
-  if command -v python >/dev/null 2>&1; then
-    printf '%s\n' python
-    return 0
-  fi
+    if command -v python >/dev/null 2>&1; then
+        printf '%s\n' python
+        return 0
+    fi
 
-  return 1
+    return 1
 }
 
 _CLV2_PYTHON_CMD="$(_clv2_resolve_python_cmd 2>/dev/null || true)"
@@ -50,118 +50,118 @@ CLV2_OBSERVER_PROMPT_PATTERN='Can you confirm|requires permission|Awaiting (user
 export CLV2_OBSERVER_PROMPT_PATTERN
 
 _clv2_detect_project() {
-  local project_root=""
-  local project_name=""
-  local project_id=""
-  local source_hint=""
+    local project_root=""
+    local project_name=""
+    local project_id=""
+    local source_hint=""
 
-  # 1. Try CLAUDE_PROJECT_DIR env var
-  if [ -n "$CLAUDE_PROJECT_DIR" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
-    project_root="$CLAUDE_PROJECT_DIR"
-    source_hint="env"
-  fi
-
-  # 2. Try git repo root from CWD (only if git is available)
-  if [ -z "$project_root" ] && command -v git &>/dev/null; then
-    project_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    if [ -n "$project_root" ]; then
-      source_hint="git"
+    # 1. Try CLAUDE_PROJECT_DIR env var
+    if [ -n "$CLAUDE_PROJECT_DIR" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
+        project_root="$CLAUDE_PROJECT_DIR"
+        source_hint="env"
     fi
-  fi
 
-  # 3. No project detected — fall back to global
-  if [ -z "$project_root" ]; then
-    _CLV2_PROJECT_ID="global"
-    _CLV2_PROJECT_NAME="global"
-    _CLV2_PROJECT_ROOT=""
-    _CLV2_PROJECT_DIR="${_CLV2_HOMUNCULUS_DIR}"
-    return 0
-  fi
-
-  # Derive project name from directory basename
-  project_name=$(basename "$project_root")
-
-  # Derive project ID: prefer git remote URL hash (portable across machines),
-  # fall back to path hash (machine-specific but still useful)
-  local remote_url=""
-  if command -v git &>/dev/null; then
-    if [ "$source_hint" = "git" ] || [ -e "${project_root}/.git" ]; then
-      remote_url=$(git -C "$project_root" remote get-url origin 2>/dev/null || true)
+    # 2. Try git repo root from CWD (only if git is available)
+    if [ -z "$project_root" ] && command -v git &>/dev/null; then
+        project_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+        if [ -n "$project_root" ]; then
+            source_hint="git"
+        fi
     fi
-  fi
 
-  # Compute hash from the original remote URL (legacy, for backward compatibility)
-  local legacy_hash_input="${remote_url:-$project_root}"
-
-  # Strip embedded credentials from remote URL (e.g., https://ghp_xxxx@github.com/...)
-  if [ -n "$remote_url" ]; then
-    remote_url=$(printf '%s' "$remote_url" | sed -E 's|://[^@]+@|://|')
-  fi
-
-  local hash_input="${remote_url:-$project_root}"
-  # Prefer Python for consistent SHA256 behavior across shells/platforms.
-  if [ -n "$_CLV2_PYTHON_CMD" ]; then
-    project_id=$(printf '%s' "$hash_input" | "$_CLV2_PYTHON_CMD" -c "import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:12])" 2>/dev/null)
-  fi
-
-  # Fallback if Python is unavailable or hash generation failed.
-  if [ -z "$project_id" ]; then
-    project_id=$(printf '%s' "$hash_input" | shasum -a 256 2>/dev/null | cut -c1-12 || \
-                 printf '%s' "$hash_input" | sha256sum 2>/dev/null | cut -c1-12 || \
-                 echo "fallback")
-  fi
-
-  # Backward compatibility: if credentials were stripped and the hash changed,
-  # check if a project dir exists under the legacy hash and reuse it
-  if [ "$legacy_hash_input" != "$hash_input" ] && [ -n "$_CLV2_PYTHON_CMD" ]; then
-    local legacy_id=""
-    legacy_id=$(printf '%s' "$legacy_hash_input" | "$_CLV2_PYTHON_CMD" -c "import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:12])" 2>/dev/null)
-    if [ -n "$legacy_id" ] && [ -d "${_CLV2_PROJECTS_DIR}/${legacy_id}" ] && [ ! -d "${_CLV2_PROJECTS_DIR}/${project_id}" ]; then
-      # Migrate legacy directory to new hash
-      mv "${_CLV2_PROJECTS_DIR}/${legacy_id}" "${_CLV2_PROJECTS_DIR}/${project_id}" 2>/dev/null || project_id="$legacy_id"
+    # 3. No project detected — fall back to global
+    if [ -z "$project_root" ]; then
+        _CLV2_PROJECT_ID="global"
+        _CLV2_PROJECT_NAME="global"
+        _CLV2_PROJECT_ROOT=""
+        _CLV2_PROJECT_DIR="${_CLV2_HOMUNCULUS_DIR}"
+        return 0
     fi
-  fi
 
-  # Export results
-  _CLV2_PROJECT_ID="$project_id"
-  _CLV2_PROJECT_NAME="$project_name"
-  _CLV2_PROJECT_ROOT="$project_root"
-  _CLV2_PROJECT_DIR="${_CLV2_PROJECTS_DIR}/${project_id}"
+    # Derive project name from directory basename
+    project_name=$(basename "$project_root")
 
-  # Ensure project directory structure exists
-  mkdir -p "${_CLV2_PROJECT_DIR}/instincts/personal"
-  mkdir -p "${_CLV2_PROJECT_DIR}/instincts/inherited"
-  mkdir -p "${_CLV2_PROJECT_DIR}/observations.archive"
-  mkdir -p "${_CLV2_PROJECT_DIR}/evolved/skills"
-  mkdir -p "${_CLV2_PROJECT_DIR}/evolved/commands"
-  mkdir -p "${_CLV2_PROJECT_DIR}/evolved/agents"
+    # Derive project ID: prefer git remote URL hash (portable across machines),
+    # fall back to path hash (machine-specific but still useful)
+    local remote_url=""
+    if command -v git &>/dev/null; then
+        if [ "$source_hint" = "git" ] || [ -e "${project_root}/.git" ]; then
+            remote_url=$(git -C "$project_root" remote get-url origin 2>/dev/null || true)
+        fi
+    fi
 
-  # Update project registry (lightweight JSON mapping)
-  _clv2_update_project_registry "$project_id" "$project_name" "$project_root" "$remote_url"
+    # Compute hash from the original remote URL (legacy, for backward compatibility)
+    local legacy_hash_input="${remote_url:-$project_root}"
+
+    # Strip embedded credentials from remote URL (e.g., https://ghp_xxxx@github.com/...)
+    if [ -n "$remote_url" ]; then
+        remote_url=$(printf '%s' "$remote_url" | sed -E 's|://[^@]+@|://|')
+    fi
+
+    local hash_input="${remote_url:-$project_root}"
+    # Prefer Python for consistent SHA256 behavior across shells/platforms.
+    if [ -n "$_CLV2_PYTHON_CMD" ]; then
+        project_id=$(printf '%s' "$hash_input" | "$_CLV2_PYTHON_CMD" -c "import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:12])" 2>/dev/null)
+    fi
+
+    # Fallback if Python is unavailable or hash generation failed.
+    if [ -z "$project_id" ]; then
+        project_id=$(printf '%s' "$hash_input" | shasum -a 256 2>/dev/null | cut -c1-12 ||
+            printf '%s' "$hash_input" | sha256sum 2>/dev/null | cut -c1-12 ||
+            echo "fallback")
+    fi
+
+    # Backward compatibility: if credentials were stripped and the hash changed,
+    # check if a project dir exists under the legacy hash and reuse it
+    if [ "$legacy_hash_input" != "$hash_input" ] && [ -n "$_CLV2_PYTHON_CMD" ]; then
+        local legacy_id=""
+        legacy_id=$(printf '%s' "$legacy_hash_input" | "$_CLV2_PYTHON_CMD" -c "import sys,hashlib; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:12])" 2>/dev/null)
+        if [ -n "$legacy_id" ] && [ -d "${_CLV2_PROJECTS_DIR}/${legacy_id}" ] && [ ! -d "${_CLV2_PROJECTS_DIR}/${project_id}" ]; then
+            # Migrate legacy directory to new hash
+            mv "${_CLV2_PROJECTS_DIR}/${legacy_id}" "${_CLV2_PROJECTS_DIR}/${project_id}" 2>/dev/null || project_id="$legacy_id"
+        fi
+    fi
+
+    # Export results
+    _CLV2_PROJECT_ID="$project_id"
+    _CLV2_PROJECT_NAME="$project_name"
+    _CLV2_PROJECT_ROOT="$project_root"
+    _CLV2_PROJECT_DIR="${_CLV2_PROJECTS_DIR}/${project_id}"
+
+    # Ensure project directory structure exists
+    mkdir -p "${_CLV2_PROJECT_DIR}/instincts/personal"
+    mkdir -p "${_CLV2_PROJECT_DIR}/instincts/inherited"
+    mkdir -p "${_CLV2_PROJECT_DIR}/observations.archive"
+    mkdir -p "${_CLV2_PROJECT_DIR}/evolved/skills"
+    mkdir -p "${_CLV2_PROJECT_DIR}/evolved/commands"
+    mkdir -p "${_CLV2_PROJECT_DIR}/evolved/agents"
+
+    # Update project registry (lightweight JSON mapping)
+    _clv2_update_project_registry "$project_id" "$project_name" "$project_root" "$remote_url"
 }
 
 _clv2_update_project_registry() {
-  local pid="$1"
-  local pname="$2"
-  local proot="$3"
-  local premote="$4"
-  local pdir="$_CLV2_PROJECT_DIR"
+    local pid="$1"
+    local pname="$2"
+    local proot="$3"
+    local premote="$4"
+    local pdir="$_CLV2_PROJECT_DIR"
 
-  mkdir -p "$(dirname "$_CLV2_REGISTRY_FILE")"
+    mkdir -p "$(dirname "$_CLV2_REGISTRY_FILE")"
 
-  if [ -z "$_CLV2_PYTHON_CMD" ]; then
-    return 0
-  fi
+    if [ -z "$_CLV2_PYTHON_CMD" ]; then
+        return 0
+    fi
 
-  # Pass values via env vars to avoid shell→python injection.
-  # Python reads them with os.environ, which is safe for any string content.
-  _CLV2_REG_PID="$pid" \
-  _CLV2_REG_PNAME="$pname" \
-  _CLV2_REG_PROOT="$proot" \
-  _CLV2_REG_PREMOTE="$premote" \
-  _CLV2_REG_PDIR="$pdir" \
-  _CLV2_REG_FILE="$_CLV2_REGISTRY_FILE" \
-  "$_CLV2_PYTHON_CMD" -c '
+    # Pass values via env vars to avoid shell→python injection.
+    # Python reads them with os.environ, which is safe for any string content.
+    _CLV2_REG_PID="$pid" \
+        _CLV2_REG_PNAME="$pname" \
+        _CLV2_REG_PROOT="$proot" \
+        _CLV2_REG_PREMOTE="$premote" \
+        _CLV2_REG_PDIR="$pdir" \
+        _CLV2_REG_FILE="$_CLV2_REGISTRY_FILE" \
+        "$_CLV2_PYTHON_CMD" -c '
 import json, os, tempfile
 from datetime import datetime, timezone
 
@@ -221,8 +221,8 @@ PROJECT_ROOT="$_CLV2_PROJECT_ROOT"
 PROJECT_DIR="$_CLV2_PROJECT_DIR"
 
 if [ -n "$PROJECT_ROOT" ]; then
-  CLV2_OBSERVER_SENTINEL_FILE="${PROJECT_ROOT}/.observer.lock"
+    CLV2_OBSERVER_SENTINEL_FILE="${PROJECT_ROOT}/.observer.lock"
 else
-  CLV2_OBSERVER_SENTINEL_FILE="${PROJECT_DIR}/.observer.lock"
+    CLV2_OBSERVER_SENTINEL_FILE="${PROJECT_DIR}/.observer.lock"
 fi
 export CLV2_OBSERVER_SENTINEL_FILE

--- a/dotfiles/.claude/skills/rules-distill/scripts/scan-rules.sh
+++ b/dotfiles/.claude/skills/rules-distill/scripts/scan-rules.sh
@@ -11,14 +11,14 @@ set -euo pipefail
 RULES_DIR="${RULES_DISTILL_DIR:-${1:-$HOME/.claude/rules}}"
 
 if [[ ! -d "$RULES_DIR" ]]; then
-  jq -n --arg path "$RULES_DIR" '{"error":"rules directory not found","path":$path}' >&2
-  exit 1
+    jq -n --arg path "$RULES_DIR" '{"error":"rules directory not found","path":$path}' >&2
+    exit 1
 fi
 
 # Collect all .md files (excluding _archived/)
 files=()
 while IFS= read -r f; do
-  files+=("$f")
+    files+=("$f")
 done < <(find "$RULES_DIR" -name '*.md' -not -path '*/_archived/*' -print | sort)
 
 total=${#files[@]}
@@ -28,31 +28,31 @@ _rules_cleanup() { rm -rf "$tmpdir"; }
 trap _rules_cleanup EXIT
 
 for i in "${!files[@]}"; do
-  file="${files[$i]}"
-  rel_path="${file#"$HOME"/}"
-  rel_path="~/$rel_path"
+    file="${files[$i]}"
+    rel_path="${file#"$HOME"/}"
+    rel_path="~/$rel_path"
 
-  # Extract H2 headings (## Title) into a JSON array via jq
-  headings_json=$({ grep -E '^## ' "$file" 2>/dev/null || true; } | sed 's/^## //' | jq -R . | jq -s '.')
+    # Extract H2 headings (## Title) into a JSON array via jq
+    headings_json=$({ grep -E '^## ' "$file" 2>/dev/null || true; } | sed 's/^## //' | jq -R . | jq -s '.')
 
-  # Get line count
-  line_count=$(wc -l < "$file" | tr -d ' ')
+    # Get line count
+    line_count=$(wc -l <"$file" | tr -d ' ')
 
-  jq -n \
-    --arg path "$rel_path" \
-    --arg file "$(basename "$file")" \
-    --argjson lines "$line_count" \
-    --argjson headings "$headings_json" \
-    '{path:$path,file:$file,lines:$lines,headings:$headings}' \
-    > "$tmpdir/$i.json"
+    jq -n \
+        --arg path "$rel_path" \
+        --arg file "$(basename "$file")" \
+        --argjson lines "$line_count" \
+        --argjson headings "$headings_json" \
+        '{path:$path,file:$file,lines:$lines,headings:$headings}' \
+        >"$tmpdir/$i.json"
 done
 
 if [[ ${#files[@]} -eq 0 ]]; then
-  jq -n --arg dir "$RULES_DIR" '{rules_dir:$dir,total:0,rules:[]}'
+    jq -n --arg dir "$RULES_DIR" '{rules_dir:$dir,total:0,rules:[]}'
 else
-  jq -n \
-    --arg dir "$RULES_DIR" \
-    --argjson total "$total" \
-    --argjson rules "$(jq -s '.' "$tmpdir"/*.json)" \
-    '{rules_dir:$dir,total:$total,rules:$rules}'
+    jq -n \
+        --arg dir "$RULES_DIR" \
+        --argjson total "$total" \
+        --argjson rules "$(jq -s '.' "$tmpdir"/*.json)" \
+        '{rules_dir:$dir,total:$total,rules:$rules}'
 fi

--- a/dotfiles/.claude/skills/rules-distill/scripts/scan-skills.sh
+++ b/dotfiles/.claude/skills/rules-distill/scripts/scan-skills.sh
@@ -18,14 +18,14 @@ CWD_SKILLS_DIR="${RULES_DISTILL_PROJECT_DIR:-${1:-$PWD/.claude/skills}}"
 # Validate CWD_SKILLS_DIR looks like a .claude/skills path (defense-in-depth).
 # Only warn when the path exists — a nonexistent path poses no traversal risk.
 if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$CWD_SKILLS_DIR" != */.claude/skills* ]]; then
-  echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
+    echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
 fi
 
 # Extract a frontmatter field (handles both quoted and unquoted single-line values).
 # Does NOT support multi-line YAML blocks (| or >) or nested YAML keys.
 extract_field() {
-  local file="$1" field="$2"
-  awk -v f="$field" '
+    local file="$1" field="$2"
+    awk -v f="$field" '
     BEGIN { fm=0 }
     /^---$/ { fm++; next }
     fm==1 {
@@ -44,46 +44,46 @@ extract_field() {
 
 # Get file mtime in UTC ISO8601 (portable: GNU and BSD)
 get_mtime() {
-  local file="$1"
-  local secs
-  secs=$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null) || return 1
-  date -u -d "@$secs" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
-  date -u -r "$secs" +%Y-%m-%dT%H:%M:%SZ
+    local file="$1"
+    local secs
+    secs=$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null) || return 1
+    date -u -d "@$secs" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+        date -u -r "$secs" +%Y-%m-%dT%H:%M:%SZ
 }
 
 # Scan a directory and produce a JSON array of skill objects
 scan_dir_to_json() {
-  local dir="$1"
+    local dir="$1"
 
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  local _scan_tmpdir="$tmpdir"
-  _scan_cleanup() { rm -rf "$_scan_tmpdir"; }
-  trap _scan_cleanup RETURN
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local _scan_tmpdir="$tmpdir"
+    _scan_cleanup() { rm -rf "$_scan_tmpdir"; }
+    trap _scan_cleanup RETURN
 
-  local i=0
-  while IFS= read -r file; do
-    local name desc mtime dp
-    name=$(extract_field "$file" "name")
-    desc=$(extract_field "$file" "description")
-    mtime=$(get_mtime "$file")
-    dp="${file/#$HOME/~}"
+    local i=0
+    while IFS= read -r file; do
+        local name desc mtime dp
+        name=$(extract_field "$file" "name")
+        desc=$(extract_field "$file" "description")
+        mtime=$(get_mtime "$file")
+        dp="${file/#$HOME/~}"
 
-    jq -n \
-      --arg path "$dp" \
-      --arg name "$name" \
-      --arg description "$desc" \
-      --arg mtime "$mtime" \
-      '{path:$path,name:$name,description:$description,mtime:$mtime}' \
-      > "$tmpdir/$i.json"
-    i=$((i+1))
-  done < <(find "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+        jq -n \
+            --arg path "$dp" \
+            --arg name "$name" \
+            --arg description "$desc" \
+            --arg mtime "$mtime" \
+            '{path:$path,name:$name,description:$description,mtime:$mtime}' \
+            >"$tmpdir/$i.json"
+        i=$((i + 1))
+    done < <(find "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 
-  if [[ $i -eq 0 ]]; then
-    echo "[]"
-  else
-    jq -s '.' "$tmpdir"/*.json
-  fi
+    if [[ $i -eq 0 ]]; then
+        echo "[]"
+    else
+        jq -s '.' "$tmpdir"/*.json
+    fi
 }
 
 # --- Main ---
@@ -93,9 +93,9 @@ global_count=0
 global_skills="[]"
 
 if [[ -d "$GLOBAL_DIR" ]]; then
-  global_found="true"
-  global_skills=$(scan_dir_to_json "$GLOBAL_DIR")
-  global_count=$(echo "$global_skills" | jq 'length')
+    global_found="true"
+    global_skills=$(scan_dir_to_json "$GLOBAL_DIR")
+    global_count=$(echo "$global_skills" | jq 'length')
 fi
 
 project_found="false"
@@ -104,23 +104,23 @@ project_count=0
 project_skills="[]"
 
 if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" ]]; then
-  project_found="true"
-  project_path="$CWD_SKILLS_DIR"
-  project_skills=$(scan_dir_to_json "$CWD_SKILLS_DIR")
-  project_count=$(echo "$project_skills" | jq 'length')
+    project_found="true"
+    project_path="$CWD_SKILLS_DIR"
+    project_skills=$(scan_dir_to_json "$CWD_SKILLS_DIR")
+    project_count=$(echo "$project_skills" | jq 'length')
 fi
 
 # Merge global + project skills into one array
 all_skills=$(jq -s 'add' <(echo "$global_skills") <(echo "$project_skills"))
 
 jq -n \
-  --arg global_found "$global_found" \
-  --argjson global_count "$global_count" \
-  --arg project_found "$project_found" \
-  --arg project_path "$project_path" \
-  --argjson project_count "$project_count" \
-  --argjson skills "$all_skills" \
-  '{
+    --arg global_found "$global_found" \
+    --argjson global_count "$global_count" \
+    --arg project_found "$project_found" \
+    --arg project_path "$project_path" \
+    --argjson project_count "$project_count" \
+    --argjson skills "$all_skills" \
+    '{
     scan_summary: {
       global: { found: ($global_found == "true"), count: $global_count },
       project: { found: ($project_found == "true"), path: $project_path, count: $project_count }

--- a/dotfiles/.claude/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/dotfiles/.claude/skills/skill-stocktake/scripts/quick-diff.sh
@@ -18,14 +18,14 @@ CWD_SKILLS_DIR="${SKILL_STOCKTAKE_PROJECT_DIR:-${2:-$PWD/.claude/skills}}"
 GLOBAL_DIR="${SKILL_STOCKTAKE_GLOBAL_DIR:-$HOME/.claude/skills}"
 
 if [[ -z "$RESULTS_JSON" || ! -f "$RESULTS_JSON" ]]; then
-  echo "Error: RESULTS_JSON not found: ${RESULTS_JSON:-<empty>}" >&2
-  exit 1
+    echo "Error: RESULTS_JSON not found: ${RESULTS_JSON:-<empty>}" >&2
+    exit 1
 fi
 
 # Validate CWD_SKILLS_DIR looks like a .claude/skills path (defense-in-depth).
 # Only warn when the path exists — a nonexistent path poses no traversal risk.
 if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$CWD_SKILLS_DIR" != */.claude/skills* ]]; then
-  echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
+    echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
 fi
 
 evaluated_at=$(jq -r '.evaluated_at' "$RESULTS_JSON")
@@ -33,8 +33,8 @@ evaluated_at=$(jq -r '.evaluated_at' "$RESULTS_JSON")
 # Fail fast on a missing or malformed evaluated_at rather than producing
 # unpredictable results from ISO 8601 string comparison against "null".
 if [[ ! "$evaluated_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
-  echo "Error: invalid or missing evaluated_at in $RESULTS_JSON: $evaluated_at" >&2
-  exit 1
+    echo "Error: invalid or missing evaluated_at in $RESULTS_JSON: $evaluated_at" >&2
+    exit 1
 fi
 
 # Pre-extract known paths from results.json once (O(1) lookup per file instead of O(n*m))
@@ -50,38 +50,38 @@ trap _cleanup EXIT
 i=0
 
 process_dir() {
-  local dir="$1"
-  while IFS= read -r file; do
-    local mtime dp is_new
-    mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
-    dp="${file/#$HOME/~}"
+    local dir="$1"
+    while IFS= read -r file; do
+        local mtime dp is_new
+        mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
+        dp="${file/#$HOME/~}"
 
-    # Check if this file is known to results.json (exact whole-line match to
-    # avoid substring false-positives, e.g. "python-patterns" matching "python-patterns-v2").
-    if echo "$known_paths" | grep -qxF "$dp"; then
-      is_new="false"
-      # Known file: only emit if mtime changed (ISO 8601 string comparison is safe)
-      [[ "$mtime" > "$evaluated_at" ]] || continue
-    else
-      is_new="true"
-      # New file: always emit regardless of mtime
-    fi
+        # Check if this file is known to results.json (exact whole-line match to
+        # avoid substring false-positives, e.g. "python-patterns" matching "python-patterns-v2").
+        if echo "$known_paths" | grep -qxF "$dp"; then
+            is_new="false"
+            # Known file: only emit if mtime changed (ISO 8601 string comparison is safe)
+            [[ "$mtime" > "$evaluated_at" ]] || continue
+        else
+            is_new="true"
+            # New file: always emit regardless of mtime
+        fi
 
-    jq -n \
-      --arg path "$dp" \
-      --arg mtime "$mtime" \
-      --argjson is_new "$is_new" \
-      '{path:$path,mtime:$mtime,is_new:$is_new}' \
-      > "$tmpdir/$i.json"
-    i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+        jq -n \
+            --arg path "$dp" \
+            --arg mtime "$mtime" \
+            --argjson is_new "$is_new" \
+            '{path:$path,mtime:$mtime,is_new:$is_new}' \
+            >"$tmpdir/$i.json"
+        i=$((i + 1))
+    done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"
 [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" ]] && process_dir "$CWD_SKILLS_DIR"
 
 if [[ $i -eq 0 ]]; then
-  echo "[]"
+    echo "[]"
 else
-  jq -s '.' "$tmpdir"/*.json
+    jq -s '.' "$tmpdir"/*.json
 fi

--- a/dotfiles/.claude/skills/skill-stocktake/scripts/save-results.sh
+++ b/dotfiles/.claude/skills/skill-stocktake/scripts/save-results.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 RESULTS_JSON="${1:-}"
 
 if [[ -z "$RESULTS_JSON" ]]; then
-  echo "Error: RESULTS_JSON argument required" >&2
-  echo "Usage: save-results.sh RESULTS_JSON <<< \"\$EVAL_JSON\"" >&2
-  exit 1
+    echo "Error: RESULTS_JSON argument required" >&2
+    echo "Usage: save-results.sh RESULTS_JSON <<< \"\$EVAL_JSON\"" >&2
+    exit 1
 fi
 
 EVALUATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -24,15 +24,15 @@ EVALUATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 # Read eval results from stdin and validate JSON before touching the results file
 input_json=$(cat)
 if ! echo "$input_json" | jq empty 2>/dev/null; then
-  echo "Error: stdin is not valid JSON" >&2
-  exit 1
+    echo "Error: stdin is not valid JSON" >&2
+    exit 1
 fi
 
 if [[ ! -f "$RESULTS_JSON" ]]; then
-  # Bootstrap: create new results.json from stdin JSON + current UTC timestamp
-  echo "$input_json" | jq --arg ea "$EVALUATED_AT" \
-    '. + { evaluated_at: $ea }' > "$RESULTS_JSON"
-  exit 0
+    # Bootstrap: create new results.json from stdin JSON + current UTC timestamp
+    echo "$input_json" | jq --arg ea "$EVALUATED_AT" \
+        '. + { evaluated_at: $ea }' >"$RESULTS_JSON"
+    exit 0
 fi
 
 # Merge: new .skills override existing ones; old skills not in input_json are kept.
@@ -44,13 +44,13 @@ tmp=$(mktemp "${RESULTS_JSON}.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
 
 jq -s \
-  --arg ea "$EVALUATED_AT" \
-  '.[0] as $existing | .[1] as $new |
+    --arg ea "$EVALUATED_AT" \
+    '.[0] as $existing | .[1] as $new |
    $existing |
    .evaluated_at = $ea |
    .skills = ($existing.skills + ($new.skills // {})) |
    if ($new | has("mode")) then .mode = $new.mode else . end |
    if ($new | has("batch_progress")) then .batch_progress = $new.batch_progress else . end' \
-  "$RESULTS_JSON" <(echo "$input_json") > "$tmp"
+    "$RESULTS_JSON" <(echo "$input_json") >"$tmp"
 
 mv "$tmp" "$RESULTS_JSON"

--- a/dotfiles/.claude/skills/skill-stocktake/scripts/scan.sh
+++ b/dotfiles/.claude/skills/skill-stocktake/scripts/scan.sh
@@ -22,14 +22,14 @@ OBSERVATIONS="${SKILL_STOCKTAKE_OBSERVATIONS:-$HOME/.claude/observations.jsonl}"
 # Validate CWD_SKILLS_DIR looks like a .claude/skills path (defense-in-depth).
 # Only warn when the path exists — a nonexistent path poses no traversal risk.
 if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$CWD_SKILLS_DIR" != */.claude/skills* ]]; then
-  echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
+    echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
 fi
 
 # Extract a frontmatter field (handles both quoted and unquoted single-line values).
 # Does NOT support multi-line YAML blocks (| or >) or nested YAML keys.
 extract_field() {
-  local file="$1" field="$2"
-  awk -v f="$field" '
+    local file="$1" field="$2"
+    awk -v f="$field" '
     BEGIN { fm=0 }
     /^---$/ { fm++; next }
     fm==1 {
@@ -48,83 +48,83 @@ extract_field() {
 
 # Get UTC timestamp N days ago (supports both macOS and GNU date)
 date_ago() {
-  local n="$1"
-  date -u -v-"${n}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
-  date -u -d "${n} days ago" +%Y-%m-%dT%H:%M:%SZ
+    local n="$1"
+    date -u -v-"${n}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+        date -u -d "${n} days ago" +%Y-%m-%dT%H:%M:%SZ
 }
 
 # Count observations matching a file path since a cutoff timestamp
 count_obs() {
-  local file="$1" cutoff="$2"
-  if [[ ! -f "$OBSERVATIONS" ]]; then
-    echo 0
-    return
-  fi
-  jq -r --arg p "$file" --arg c "$cutoff" \
-    'select(.tool=="Read" and .path==$p and .timestamp>=$c) | 1' \
-    "$OBSERVATIONS" 2>/dev/null | wc -l | tr -d ' '
+    local file="$1" cutoff="$2"
+    if [[ ! -f "$OBSERVATIONS" ]]; then
+        echo 0
+        return
+    fi
+    jq -r --arg p "$file" --arg c "$cutoff" \
+        'select(.tool=="Read" and .path==$p and .timestamp>=$c) | 1' \
+        "$OBSERVATIONS" 2>/dev/null | wc -l | tr -d ' '
 }
 
 # Scan a directory and produce a JSON array of skill objects
 scan_dir_to_json() {
-  local dir="$1"
-  local c7 c30
-  c7=$(date_ago 7)
-  c30=$(date_ago 30)
+    local dir="$1"
+    local c7 c30
+    c7=$(date_ago 7)
+    c30=$(date_ago 30)
 
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  # Use a function to avoid embedding $tmpdir in a quoted string (prevents injection
-  # if TMPDIR were crafted to contain shell metacharacters).
-  local _scan_tmpdir="$tmpdir"
-  _scan_cleanup() { rm -rf "$_scan_tmpdir"; }
-  trap _scan_cleanup RETURN
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Use a function to avoid embedding $tmpdir in a quoted string (prevents injection
+    # if TMPDIR were crafted to contain shell metacharacters).
+    local _scan_tmpdir="$tmpdir"
+    _scan_cleanup() { rm -rf "$_scan_tmpdir"; }
+    trap _scan_cleanup RETURN
 
-  # Pre-aggregate observation counts in two passes (one per window) instead of
-  # calling jq per-file — reduces from O(n*m) to O(n+m) jq invocations.
-  local obs_7d_counts obs_30d_counts
-  obs_7d_counts=""
-  obs_30d_counts=""
-  if [[ -f "$OBSERVATIONS" ]]; then
-    obs_7d_counts=$(jq -r --arg c "$c7" \
-      'select(.tool=="Read" and .timestamp>=$c) | .path' \
-      "$OBSERVATIONS" 2>/dev/null | sort | uniq -c)
-    obs_30d_counts=$(jq -r --arg c "$c30" \
-      'select(.tool=="Read" and .timestamp>=$c) | .path' \
-      "$OBSERVATIONS" 2>/dev/null | sort | uniq -c)
-  fi
+    # Pre-aggregate observation counts in two passes (one per window) instead of
+    # calling jq per-file — reduces from O(n*m) to O(n+m) jq invocations.
+    local obs_7d_counts obs_30d_counts
+    obs_7d_counts=""
+    obs_30d_counts=""
+    if [[ -f "$OBSERVATIONS" ]]; then
+        obs_7d_counts=$(jq -r --arg c "$c7" \
+            'select(.tool=="Read" and .timestamp>=$c) | .path' \
+            "$OBSERVATIONS" 2>/dev/null | sort | uniq -c)
+        obs_30d_counts=$(jq -r --arg c "$c30" \
+            'select(.tool=="Read" and .timestamp>=$c) | .path' \
+            "$OBSERVATIONS" 2>/dev/null | sort | uniq -c)
+    fi
 
-  local i=0
-  while IFS= read -r file; do
-    local name desc mtime u7 u30 dp
-    name=$(extract_field "$file" "name")
-    desc=$(extract_field "$file" "description")
-    mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
-    # Use awk exact field match to avoid substring false-positives from grep -F.
-    # uniq -c output format: "   N /path/to/file" — path is always field 2.
-    u7=$(echo "$obs_7d_counts" | awk -v f="$file" '$2 == f {print $1}' | head -1)
-    u7="${u7:-0}"
-    u30=$(echo "$obs_30d_counts" | awk -v f="$file" '$2 == f {print $1}' | head -1)
-    u30="${u30:-0}"
-    dp="${file/#$HOME/~}"
+    local i=0
+    while IFS= read -r file; do
+        local name desc mtime u7 u30 dp
+        name=$(extract_field "$file" "name")
+        desc=$(extract_field "$file" "description")
+        mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
+        # Use awk exact field match to avoid substring false-positives from grep -F.
+        # uniq -c output format: "   N /path/to/file" — path is always field 2.
+        u7=$(echo "$obs_7d_counts" | awk -v f="$file" '$2 == f {print $1}' | head -1)
+        u7="${u7:-0}"
+        u30=$(echo "$obs_30d_counts" | awk -v f="$file" '$2 == f {print $1}' | head -1)
+        u30="${u30:-0}"
+        dp="${file/#$HOME/~}"
 
-    jq -n \
-      --arg path "$dp" \
-      --arg name "$name" \
-      --arg description "$desc" \
-      --arg mtime "$mtime" \
-      --argjson use_7d "$u7" \
-      --argjson use_30d "$u30" \
-      '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
-      > "$tmpdir/$i.json"
-    i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+        jq -n \
+            --arg path "$dp" \
+            --arg name "$name" \
+            --arg description "$desc" \
+            --arg mtime "$mtime" \
+            --argjson use_7d "$u7" \
+            --argjson use_30d "$u30" \
+            '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
+            >"$tmpdir/$i.json"
+        i=$((i + 1))
+    done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
 
-  if [[ $i -eq 0 ]]; then
-    echo "[]"
-  else
-    jq -s '.' "$tmpdir"/*.json
-  fi
+    if [[ $i -eq 0 ]]; then
+        echo "[]"
+    else
+        jq -s '.' "$tmpdir"/*.json
+    fi
 }
 
 # --- Main ---
@@ -134,9 +134,9 @@ global_count=0
 global_skills="[]"
 
 if [[ -d "$GLOBAL_DIR" ]]; then
-  global_found="true"
-  global_skills=$(scan_dir_to_json "$GLOBAL_DIR")
-  global_count=$(echo "$global_skills" | jq 'length')
+    global_found="true"
+    global_skills=$(scan_dir_to_json "$GLOBAL_DIR")
+    global_count=$(echo "$global_skills" | jq 'length')
 fi
 
 project_found="false"
@@ -145,23 +145,23 @@ project_count=0
 project_skills="[]"
 
 if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" ]]; then
-  project_found="true"
-  project_path="$CWD_SKILLS_DIR"
-  project_skills=$(scan_dir_to_json "$CWD_SKILLS_DIR")
-  project_count=$(echo "$project_skills" | jq 'length')
+    project_found="true"
+    project_path="$CWD_SKILLS_DIR"
+    project_skills=$(scan_dir_to_json "$CWD_SKILLS_DIR")
+    project_count=$(echo "$project_skills" | jq 'length')
 fi
 
 # Merge global + project skills into one array
 all_skills=$(jq -s 'add' <(echo "$global_skills") <(echo "$project_skills"))
 
 jq -n \
-  --arg global_found "$global_found" \
-  --argjson global_count "$global_count" \
-  --arg project_found "$project_found" \
-  --arg project_path "$project_path" \
-  --argjson project_count "$project_count" \
-  --argjson skills "$all_skills" \
-  '{
+    --arg global_found "$global_found" \
+    --argjson global_count "$global_count" \
+    --arg project_found "$project_found" \
+    --arg project_path "$project_path" \
+    --argjson project_count "$project_count" \
+    --argjson skills "$all_skills" \
+    '{
     scan_summary: {
       global: { found: ($global_found == "true"), count: $global_count },
       project: { found: ($project_found == "true"), path: $project_path, count: $project_count }

--- a/dotfiles/.claude/skills/strategic-compact/suggest-compact.sh
+++ b/dotfiles/.claude/skills/strategic-compact/suggest-compact.sh
@@ -35,20 +35,20 @@ THRESHOLD=${COMPACT_THRESHOLD:-50}
 
 # Initialize or increment counter
 if [ -f "$COUNTER_FILE" ]; then
-  count=$(cat "$COUNTER_FILE")
-  count=$((count + 1))
-  echo "$count" > "$COUNTER_FILE"
+    count=$(cat "$COUNTER_FILE")
+    count=$((count + 1))
+    echo "$count" >"$COUNTER_FILE"
 else
-  echo "1" > "$COUNTER_FILE"
-  count=1
+    echo "1" >"$COUNTER_FILE"
+    count=1
 fi
 
 # Suggest compact after threshold tool calls
 if [ "$count" -eq "$THRESHOLD" ]; then
-  echo "[StrategicCompact] $THRESHOLD tool calls reached - consider /compact if transitioning phases" >&2
+    echo "[StrategicCompact] $THRESHOLD tool calls reached - consider /compact if transitioning phases" >&2
 fi
 
 # Suggest at regular intervals after threshold
 if [ "$count" -gt "$THRESHOLD" ] && [ $((count % 25)) -eq 0 ]; then
-  echo "[StrategicCompact] $count tool calls - good checkpoint for /compact if context is stale" >&2
+    echo "[StrategicCompact] $count tool calls - good checkpoint for /compact if context is stale" >&2
 fi

--- a/dotfiles/lib/skillshare.sh
+++ b/dotfiles/lib/skillshare.sh
@@ -234,8 +234,8 @@ skillshare_run_sync() {
         return 0
     fi
     msg_step "skillshare sync --all --force を実行します (skills + agents)..."
-    printf "y\n" | skillshare sync --all --force >/dev/null 2>&1 \
-        || msg_warn "skillshare sync に失敗しました (手動で 'skillshare sync --all' を実行してください)。"
+    printf "y\n" | skillshare sync --all --force >/dev/null 2>&1 ||
+        msg_warn "skillshare sync に失敗しました (手動で 'skillshare sync --all' を実行してください)。"
 }
 
 # --- ヘルパー: Codex 用に .md エージェントを .toml に変換 ---
@@ -256,6 +256,6 @@ skillshare_convert_codex_agents() {
         return 0
     fi
     msg_step "Codex 用に .md → .toml 変換を実行します..."
-    python3 "$converter" "$agents_src" "$codex_out" \
-        || msg_warn "Codex agents の変換に失敗しました。"
+    python3 "$converter" "$agents_src" "$codex_out" ||
+        msg_warn "Codex agents の変換に失敗しました。"
 }


### PR DESCRIPTION
## 概要

CI の **Shell Format Check** (`shfmt -d -i 4 -ln bash`) 非準拠だった既存シェルスクリプト
16 ファイルを一括整形し、CI ゲートを正常化する。**整形のみで挙動変更はなし**。

これらは特定機能とは無関係の整形負債で、任意の PR の CI を常時赤にしていた
（例: #125 はコード自体 clean だが本チェックのみ赤）。

Closes #126

## 変更内容

CI と同一設定 (`shfmt -w -i 4 -ln bash`) を対象ファイル群へ適用。主な差分は
行継続 (`\`) → 末尾演算子への繰り替えとインデント調整で、**セマンティクスは不変**。

対象（16 ファイル）:
- `dotfiles/lib/skillshare.sh`
- `dotfiles/.claude/lsps-runtime/{pyright,vtsls}/hooks/check-*.sh`
- `dotfiles/.claude/scripts/{hooks/run-with-flags-shell,orchestrate-codex-worker}.sh`
- `dotfiles/.claude/skills/continuous-learning-v2/**/*.sh`
- `dotfiles/.claude/skills/rules-distill/scripts/scan-*.sh`
- `dotfiles/.claude/skills/skill-stocktake/scripts/*.sh`
- `dotfiles/.claude/skills/strategic-compact/suggest-compact.sh`

## 動作確認

- [x] `shfmt -d -i 4 -ln bash` が全対象で差分なし（冪等）
- [x] 変更ファイルすべて `bash -n` OK
- [x] `bats dotfiles/tests/` の失敗件数が baseline と同一（整形による新規失敗なし）
- [x] 差分は行繰り替え・インデントのみ（ロジック変更なし）
