### PR TITLE
fix(zsh): HISTFILE がディレクトリ化した場合に自己修復する

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -13,8 +13,14 @@ fi
 # ----------------------------
 # 履歴設定（${ZDOTDIR:-$HOME}/.zsh ディレクトリは setup.sh で作成済みの前提）
 HISTFILE="${ZDOTDIR:-$HOME}/.zsh/.zsh_history"
-# フェールセーフ: ディレクトリが存在しなければ作成
+# フェールセーフ: 親ディレクトリが存在しなければ作成
 [[ -d "${HISTFILE:h}" ]] || command mkdir -p -m 700 "${HISTFILE:h}"
+# 自己修復: HISTFILE 自体が（空の）ディレクトリ化していると zsh は履歴を書けず
+# 「failed to write history file ...: is a directory」エラーになる。
+# Docker 等のバインドマウントが未存在パスをホスト側に空ディレクトリとして
+# 作ってしまう既知の挙動が典型原因。空ディレクトリのみ安全に除去する
+# （rmdir は中身があれば失敗するため、実データを壊さない）。
+[[ -d "$HISTFILE" ]] && command rmdir "$HISTFILE" 2>/dev/null
 export HISTSIZE=50000
 export SAVEHIST=50000
 # セッション間で履歴を即時共有

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -13,20 +13,41 @@ fi
 # ----------------------------
 # 履歴設定（${ZDOTDIR:-$HOME}/.zsh ディレクトリは setup.sh で作成済みの前提）
 HISTFILE="${ZDOTDIR:-$HOME}/.zsh/.zsh_history"
-# フェールセーフ: 親ディレクトリが存在しなければ作成
-[[ -d "${HISTFILE:h}" ]] || command mkdir -p -m 700 "${HISTFILE:h}"
-# 自己修復: HISTFILE 自体が（空の）ディレクトリ化していると zsh は履歴を書けず
-# 「failed to write history file ...: is a directory」エラーになる。
-# Docker 等のバインドマウントが未存在パスをホスト側に空ディレクトリとして
-# 作ってしまう既知の挙動が典型原因。空ディレクトリのみ安全に除去する
-# （rmdir は中身があれば失敗するため、実データを壊さない）。
+# 警告は Powerlevel10k の instant prompt（本ファイル冒頭で起動済み）に
+# バッファされ隠れ得るため、即時 print せず最初のプロンプト確定後に一度だけ
+# 表示する。$_histfile_warn が設定されていれば precmd フックが拾う。
+autoload -Uz add-zsh-hook
+_histfile_notify() {
+    [[ -n "$_histfile_warn" ]] && print -ru2 -- "$_histfile_warn"
+    add-zsh-hook -d precmd _histfile_notify
+    unset _histfile_warn
+    unfunction _histfile_notify
+}
+add-zsh-hook precmd _histfile_notify
+# フェールセーフ: 親ディレクトリが無ければ作成（失敗も握り潰さず通知する）
+if [[ ! -d "${HISTFILE:h}" ]]; then
+    command mkdir -p -m 700 "${HISTFILE:h}" 2>/dev/null \
+        || _histfile_warn="[zsh] 警告: ${HISTFILE:h} を作成できず、履歴が保存されない可能性があります。"
+fi
+# 自己修復: HISTFILE 自体がディレクトリ化していると zsh は履歴を書けず
+# 「failed to write history file ...: is a directory」エラーになる。Docker 等の
+# バインドマウントが未存在パスをホスト側に空ディレクトリとして作る既知の挙動が
+# 典型原因。本ガードはこの「ディレクトリ化」のみを対象とする（FIFO 等は対象外）。
+# rmdir は中身があれば失敗するため、実データは壊さない。
 [[ -d "$HISTFILE" ]] && command rmdir "$HISTFILE" 2>/dev/null
-# それでもディレクトリのまま（非空、またはアクティブなバインドマウント等で
-# rmdir 不可）の場合は、サイレントに同じエラーへ陥らないよう、隣接する
-# フォールバック履歴ファイルへ切り替えて警告する（履歴機能自体は維持する）。
 if [[ -d "$HISTFILE" ]]; then
-    print -u2 "[zsh] 警告: ${HISTFILE} がディレクトリのため履歴を書き込めません。${HISTFILE}.local にフォールバックします。"
-    HISTFILE="${HISTFILE}.local"
+    # rmdir 不可（非空、またはアクティブなバインドマウント等）。隣接の
+    # フォールバック先へ退避するが、そこも同じ要因でディレクトリ化し得るため
+    # 再度自己修復を試み、それでも駄目なら「保存されない」と正直に通知する。
+    _histfile_fallback="${HISTFILE}.local"
+    [[ -d "$_histfile_fallback" ]] && command rmdir "$_histfile_fallback" 2>/dev/null
+    if [[ -d "$_histfile_fallback" ]]; then
+        _histfile_warn="[zsh] 警告: ${HISTFILE} と ${_histfile_fallback} が共にディレクトリのため、このセッションの履歴は保存されません。"
+    else
+        _histfile_warn="[zsh] 警告: ${HISTFILE} がディレクトリのため ${_histfile_fallback} にフォールバックしました。"
+        HISTFILE="$_histfile_fallback"
+    fi
+    unset _histfile_fallback
 fi
 export HISTSIZE=50000
 export SAVEHIST=50000

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -21,6 +21,13 @@ HISTFILE="${ZDOTDIR:-$HOME}/.zsh/.zsh_history"
 # 作ってしまう既知の挙動が典型原因。空ディレクトリのみ安全に除去する
 # （rmdir は中身があれば失敗するため、実データを壊さない）。
 [[ -d "$HISTFILE" ]] && command rmdir "$HISTFILE" 2>/dev/null
+# それでもディレクトリのまま（非空、またはアクティブなバインドマウント等で
+# rmdir 不可）の場合は、サイレントに同じエラーへ陥らないよう、隣接する
+# フォールバック履歴ファイルへ切り替えて警告する（履歴機能自体は維持する）。
+if [[ -d "$HISTFILE" ]]; then
+    print -u2 "[zsh] 警告: ${HISTFILE} がディレクトリのため履歴を書き込めません。${HISTFILE}.local にフォールバックします。"
+    HISTFILE="${HISTFILE}.local"
+fi
 export HISTSIZE=50000
 export SAVEHIST=50000
 # セッション間で履歴を即時共有

--- a/dotfiles/tests/test_zsh_history_self_heal.bats
+++ b/dotfiles/tests/test_zsh_history_self_heal.bats
@@ -19,8 +19,9 @@ setup() {
     ZSHRC="$PROJECT_ROOT/.zshrc"
     TEST_HOME="$(mktemp -d)"
 
-    # .zshrc から HISTFILE 設定ブロック（HISTFILE= 行〜 rmdir 自己修復行）を抽出。
-    HISTFILE_BLOCK="$(awk '/^HISTFILE=/{f=1} f{print} /rmdir "\$HISTFILE"/{exit}' "$ZSHRC")"
+    # .zshrc から HISTFILE 設定ブロック（HISTFILE= 行〜 export HISTSIZE= 直前）を抽出。
+    # 親ディレクトリ作成・空ディレクトリ除去・フォールバック切替を含む。
+    HISTFILE_BLOCK="$(awk '/^HISTFILE=/{f=1} /^export HISTSIZE=/{exit} f{print}' "$ZSHRC")"
     [ -n "$HISTFILE_BLOCK" ] || {
         echo "HISTFILE ブロックを .zshrc から抽出できませんでした" >&2
         return 1
@@ -84,4 +85,21 @@ run_histfile_block() {
     [ "$status" -eq 0 ]
     [ -d "$TEST_HOME/.zsh/.zsh_history" ]
     [ -f "$TEST_HOME/.zsh/.zsh_history/keep.txt" ]
+}
+
+@test "falls back to .local file when HISTFILE is a non-removable directory" {
+    # rmdir 不可なディレクトリ（非空。アクティブなバインドマウントの代理）でも、
+    # サイレントに失敗せずフォールバック先へ切り替え、警告を出し、書き込めること。
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    echo "mounted" >"$TEST_HOME/.zsh/.zsh_history/keep.txt"
+    run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c \
+        "$HISTFILE_BLOCK"$'\n'"print -r -- ': 0:0;echo fallback-test' >| \"\$HISTFILE\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"フォールバック"* ]]
+    # 元ディレクトリとその中身は保持されている。
+    [ -d "$TEST_HOME/.zsh/.zsh_history" ]
+    [ -f "$TEST_HOME/.zsh/.zsh_history/keep.txt" ]
+    # 書き込みはフォールバックファイルに行われている。
+    [ -f "$TEST_HOME/.zsh/.zsh_history.local" ]
+    grep -q "fallback-test" "$TEST_HOME/.zsh/.zsh_history.local"
 }

--- a/dotfiles/tests/test_zsh_history_self_heal.bats
+++ b/dotfiles/tests/test_zsh_history_self_heal.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# Tests for the HISTFILE self-heal guard in .zshrc
+#
+# HISTFILE 自体が（空の）ディレクトリ化していると zsh は履歴を書けず
+# 「failed to write history file ...: is a directory」エラーになる。
+# Docker 等のバインドマウントが未存在パスをホスト側に空ディレクトリとして
+# 作る既知の挙動が典型原因。.zshrc の自己修復ガードが空ディレクトリのみを
+# 安全に除去し、履歴ファイルとして書けるようになることを検証する。
+#
+# NOTE: 逐語コピーではなく .zshrc から該当ブロックを抽出して zsh 上で実行する
+#       （他のテストと同様に同期ずれを避ける）。zsh 必須。
+
+setup() {
+    if ! command -v zsh >/dev/null 2>&1; then
+        skip "zsh が見つからないためスキップ"
+    fi
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    ZSHRC="$PROJECT_ROOT/.zshrc"
+    TEST_HOME="$(mktemp -d)"
+
+    # .zshrc から HISTFILE 設定ブロック（HISTFILE= 行〜 rmdir 自己修復行）を抽出。
+    HISTFILE_BLOCK="$(awk '/^HISTFILE=/{f=1} f{print} /rmdir "\$HISTFILE"/{exit}' "$ZSHRC")"
+    [ -n "$HISTFILE_BLOCK" ] || {
+        echo "HISTFILE ブロックを .zshrc から抽出できませんでした" >&2
+        return 1
+    }
+}
+
+teardown() {
+    if [ -n "${TEST_HOME:-}" ]; then
+        chmod -R u+w "$TEST_HOME" 2>/dev/null || true
+        rm -rf "$TEST_HOME"
+    fi
+}
+
+# 抽出した HISTFILE ブロックを zsh 上で実行するヘルパ。
+run_histfile_block() {
+    run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c "$HISTFILE_BLOCK; print -r -- \"\$HISTFILE\""
+}
+
+@test "removes empty directory that occupies the HISTFILE path" {
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    run_histfile_block
+    [ "$status" -eq 0 ]
+    [ ! -d "$TEST_HOME/.zsh/.zsh_history" ]
+}
+
+@test "zsh can write the history file after self-heal" {
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    # 自己修復後に HISTFILE パスへファイルとして書き込めること（= zsh が履歴保存時に
+    # 「is a directory」エラーを出さないこと）を、実際の書き込みで検証する。
+    run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c \
+        "$HISTFILE_BLOCK"$'\n'"print -r -- ': 0:0;echo self-heal-test' >| \"\$HISTFILE\""
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_HOME/.zsh/.zsh_history" ]
+    grep -q "self-heal-test" "$TEST_HOME/.zsh/.zsh_history"
+}
+
+@test "without self-heal, writing to a directory HISTFILE fails (regression guard)" {
+    # 自己修復行が無い場合は zsh が「is a directory」で失敗することを確認し、
+    # ガードが本当に問題を解消しているという因果を担保する。
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c \
+        'HISTFILE="$HOME/.zsh/.zsh_history"; print -r -- "x" >| "$HISTFILE"'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is a directory"* ]]
+}
+
+@test "preserves an existing regular HISTFILE" {
+    command mkdir -p "$TEST_HOME/.zsh"
+    printf ': 0:0;echo existing-entry\n' >"$TEST_HOME/.zsh/.zsh_history"
+    run_histfile_block
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_HOME/.zsh/.zsh_history" ]
+    grep -q "existing-entry" "$TEST_HOME/.zsh/.zsh_history"
+}
+
+@test "leaves a non-empty directory intact (rmdir does not destroy data)" {
+    # 空でないディレクトリは rmdir が失敗するため、実データは壊れない。
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    echo "important" >"$TEST_HOME/.zsh/.zsh_history/keep.txt"
+    run_histfile_block
+    [ "$status" -eq 0 ]
+    [ -d "$TEST_HOME/.zsh/.zsh_history" ]
+    [ -f "$TEST_HOME/.zsh/.zsh_history/keep.txt" ]
+}

--- a/dotfiles/tests/test_zsh_history_self_heal.bats
+++ b/dotfiles/tests/test_zsh_history_self_heal.bats
@@ -40,6 +40,14 @@ run_histfile_block() {
     run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c "$HISTFILE_BLOCK; print -r -- \"\$HISTFILE\""
 }
 
+# ブロック実行後、登録済み precmd フックを発火させるヘルパ。
+# 警告は instant prompt 対策で precmd へ遅延されるため、非対話の -c では
+# 明示的に発火させないと表示されない。$1 に追加コマンドを渡せる。
+run_histfile_block_with_notify() {
+    run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c \
+        "$HISTFILE_BLOCK"$'\n'"${1:-}"$'\n'"for hk in \$precmd_functions; do \$hk; done"
+}
+
 @test "removes empty directory that occupies the HISTFILE path" {
     mkdir -p "$TEST_HOME/.zsh/.zsh_history"
     run_histfile_block
@@ -89,17 +97,44 @@ run_histfile_block() {
 
 @test "falls back to .local file when HISTFILE is a non-removable directory" {
     # rmdir 不可なディレクトリ（非空。アクティブなバインドマウントの代理）でも、
-    # サイレントに失敗せずフォールバック先へ切り替え、警告を出し、書き込めること。
+    # サイレントに失敗せずフォールバック先へ切り替え、書き込めること。
     mkdir -p "$TEST_HOME/.zsh/.zsh_history"
     echo "mounted" >"$TEST_HOME/.zsh/.zsh_history/keep.txt"
     run env HOME="$TEST_HOME" ZDOTDIR="$TEST_HOME" zsh -f -c \
         "$HISTFILE_BLOCK"$'\n'"print -r -- ': 0:0;echo fallback-test' >| \"\$HISTFILE\""
     [ "$status" -eq 0 ]
-    [[ "$output" == *"フォールバック"* ]]
     # 元ディレクトリとその中身は保持されている。
     [ -d "$TEST_HOME/.zsh/.zsh_history" ]
     [ -f "$TEST_HOME/.zsh/.zsh_history/keep.txt" ]
     # 書き込みはフォールバックファイルに行われている。
     [ -f "$TEST_HOME/.zsh/.zsh_history.local" ]
     grep -q "fallback-test" "$TEST_HOME/.zsh/.zsh_history.local"
+}
+
+@test "fallback warning is deferred to precmd, not emitted immediately" {
+    # instant prompt に飲まれないよう、警告はブロック実行時点では出さず、
+    # precmd フック発火後にのみ表示される（HIGH 指摘への対応の回帰ガード）。
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history"
+    echo "mounted" >"$TEST_HOME/.zsh/.zsh_history/keep.txt"
+    # 発火させない: 警告は出ない。
+    run_histfile_block
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"フォールバック"* ]]
+    # precmd 発火後: 警告が出る。
+    run_histfile_block_with_notify
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"フォールバック"* ]]
+}
+
+@test "warns history is not persisted when both paths are directories" {
+    # フォールバック先 .local も同種要因でディレクトリ化し得る。両方ディレクトリなら
+    # サイレントに同じ is a directory エラーへ陥らず、保存されない旨を正直に通知する。
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history/sub"
+    mkdir -p "$TEST_HOME/.zsh/.zsh_history.local/sub"
+    run_histfile_block_with_notify "print -r -- \"HISTFILE=\$HISTFILE\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"保存されません"* ]]
+    # 双方のディレクトリは破壊されず保持される。
+    [ -d "$TEST_HOME/.zsh/.zsh_history/sub" ]
+    [ -d "$TEST_HOME/.zsh/.zsh_history.local/sub" ]
 }


### PR DESCRIPTION
## 背景 / 問題

`exec zsh`（および通常のシェル起動）時に次のエラーが発生していた:

```
zsh: failed to write history file /home/wataru/.zsh/.zsh_history: is a directory
```

原因は **`$HISTFILE` が指すパス自体が（空の）ディレクトリになっていた**こと。
zsh は履歴ファイルとして書き込もうとするが、そこがディレクトリだと書けず失敗する。

### dev-templates 由来ではない

`.zshrc` の HISTFILE 設定を全 git 履歴で確認した結果、**どの時代も一貫して正しい**:

- `HISTFILE` は常にファイルパスとして設定
- `mkdir` の対象は常に親ディレクトリ（`${HISTFILE:h}` = `~/.zsh`）であり、`.zsh_history` 自体を `mkdir` したバージョンは皆無
- リポジトリの Docker/devcontainer もホストの `~/.zsh/.zsh_history` をマウントしていない

問題のディレクトリは dev-templates 外の何か（典型的には **Docker/Podman のバインドマウントが未存在パスをホスト側に空ディレクトリとして自動生成する既知の挙動**）が作ったものと考えられる。

## 変更内容

`.zshrc` に **自己修復ガード**を追加し、再発時にも自動回復できるようにする:

```zsh
[[ -d "$HISTFILE" ]] && command rmdir "$HISTFILE" 2>/dev/null
```

- `rmdir` は **中身があると失敗する**ため、誤って実データを破壊しない（空ディレクトリのみ除去）
- 外部要因で再びディレクトリ化しても、次回シェル起動時に自動で解消される

## テスト

`dotfiles/tests/test_zsh_history_self_heal.bats` を新規追加（zsh 上で実 `.zshrc` の該当ブロックを抽出実行）:

1. HISTFILE パスを占有する空ディレクトリを除去する
2. 自己修復後に履歴ファイルへ書き込める（`is a directory` が出ない）
3. ガード無しでは `is a directory` で失敗する（因果を担保する回帰ガード）
4. 既存の通常ファイル HISTFILE を保持する
5. 非空ディレクトリは保持する（rmdir がデータを壊さない）

### 検証結果

- `bats dotfiles/tests/*.bats` → **176/176 合格**
- `zsh -n dotfiles/.zshrc` → 構文 OK

## Test plan

- [x] 新規 bats テスト 5 件が合格
- [x] 既存 bats テスト全件が合格（リグレッション無し）
- [x] `.zshrc` の zsh 構文チェック
- [ ] CI（zsh-syntax / shfmt / shellcheck / bats / dry-run）通過確認
