### PR TITLE
chore(skillshare): CLI の pin を v0.19.12 から v0.20.7 へ更新

### DIFF
--- a/dotfiles/lib/skillshare.sh
+++ b/dotfiles/lib/skillshare.sh
@@ -15,9 +15,13 @@
 SKILLSHARE_INSTALL_DIR="${SKILLSHARE_INSTALL_DIR:-${HOME}/.local/bin}"
 SKILLSHARE_REPO="${SKILLSHARE_REPO:-runkids/skillshare}"
 SKILLSHARE_VERSION="${SKILLSHARE_VERSION:-v0.20.7}"
-# opt-in: install.sh の SHA256 期待値。空文字列なら検証スキップ。
-# 上流の install.sh が改竄/差し替えされた場合の防御線として利用する。
-SKILLSHARE_INSTALLER_SHA256="${SKILLSHARE_INSTALLER_SHA256:-}"
+# install.sh の SHA256 期待値。download 後にこの値と照合し、不一致なら install を中断する。
+# SKILLSHARE_VERSION (v0.20.7) に対応する install.sh のハッシュを pin することで、上流での
+# タグ差し替え (git tag -f) による静かな内容差し替えを検知する。tag pin だけでは raw.github
+# の内容一意性は保証されないため、その弱点を塞ぐ supply-chain 防御線。
+# NOTE: SKILLSHARE_VERSION を更新する際は、必ずこの値も新タグの install.sh のハッシュへ更新すること。
+# 空文字列 (env で SKILLSHARE_INSTALLER_SHA256= を渡す等) を指定すると検証をスキップする。
+SKILLSHARE_INSTALLER_SHA256="${SKILLSHARE_INSTALLER_SHA256:-47a67522d12ced431279d878f6f4568284bf250a85699d446f64d8a8df9deeed}"
 
 # --- ヘルパー: ファイルの SHA256 を期待値と照合する ---
 # 戻り値: 0=一致 / 1=不一致 or 検証ツール無し。

--- a/dotfiles/lib/skillshare.sh
+++ b/dotfiles/lib/skillshare.sh
@@ -17,11 +17,13 @@ SKILLSHARE_REPO="${SKILLSHARE_REPO:-runkids/skillshare}"
 SKILLSHARE_VERSION="${SKILLSHARE_VERSION:-v0.20.7}"
 # install.sh の SHA256 期待値。download 後にこの値と照合し、不一致なら install を中断する。
 # SKILLSHARE_VERSION (v0.20.7) に対応する install.sh のハッシュを pin することで、上流での
-# タグ差し替え (git tag -f) による静かな内容差し替えを検知する。tag pin だけでは raw.github
-# の内容一意性は保証されないため、その弱点を塞ぐ supply-chain 防御線。
+# タグ差し替え (git tag -f) による静かな内容差し替えを検知する。tag pin だけでは
+# raw.githubusercontent.com の内容一意性は保証されないため、その弱点を塞ぐ supply-chain 防御線。
 # NOTE: SKILLSHARE_VERSION を更新する際は、必ずこの値も新タグの install.sh のハッシュへ更新すること。
-# 空文字列 (env で SKILLSHARE_INSTALLER_SHA256= を渡す等) を指定すると検証をスキップする。
-SKILLSHARE_INSTALLER_SHA256="${SKILLSHARE_INSTALLER_SHA256:-47a67522d12ced431279d878f6f4568284bf250a85699d446f64d8a8df9deeed}"
+# NOTE: 検証を無効化したい場合は env で空文字列を明示する (例: SKILLSHARE_INSTALLER_SHA256= bash setup.sh)。
+#       空文字での opt-out を効かせるため ${var-...} (コロンなし) を使う。${var:-...} だと
+#       空文字でもデフォルト値に戻ってしまい無効化できない。
+SKILLSHARE_INSTALLER_SHA256="${SKILLSHARE_INSTALLER_SHA256-47a67522d12ced431279d878f6f4568284bf250a85699d446f64d8a8df9deeed}"
 
 # --- ヘルパー: ファイルの SHA256 を期待値と照合する ---
 # 戻り値: 0=一致 / 1=不一致 or 検証ツール無し。

--- a/dotfiles/lib/skillshare.sh
+++ b/dotfiles/lib/skillshare.sh
@@ -14,7 +14,7 @@
 #       後から書き換わっても影響を受けないようにするため tag pin する。
 SKILLSHARE_INSTALL_DIR="${SKILLSHARE_INSTALL_DIR:-${HOME}/.local/bin}"
 SKILLSHARE_REPO="${SKILLSHARE_REPO:-runkids/skillshare}"
-SKILLSHARE_VERSION="${SKILLSHARE_VERSION:-v0.19.12}"
+SKILLSHARE_VERSION="${SKILLSHARE_VERSION:-v0.20.7}"
 # opt-in: install.sh の SHA256 期待値。空文字列なら検証スキップ。
 # 上流の install.sh が改竄/差し替えされた場合の防御線として利用する。
 SKILLSHARE_INSTALLER_SHA256="${SKILLSHARE_INSTALLER_SHA256:-}"

--- a/dotfiles/tests/test_skillshare.bats
+++ b/dotfiles/tests/test_skillshare.bats
@@ -160,6 +160,14 @@ SETUP_FILE="$DOTFILES_DIR/setup.sh"
     [ "$status" -eq 0 ]
 }
 
+@test "skillshare: SHA256 default is pinned (64-hex) with colon-less default so empty env disables" {
+    # ${var:-...} だと空文字を渡してもデフォルトに戻り検証を無効化できない。
+    # 明示的な空文字での opt-out を効かせるため ${var-...} (コロンなし) を使い、
+    # かつデフォルトは 64 桁 hex の pin であること (= 既定で検証が有効) を保証する。
+    run grep -E '^SKILLSHARE_INSTALLER_SHA256="\$\{SKILLSHARE_INSTALLER_SHA256-[0-9a-f]{64}\}"' "$LIB_FILE"
+    [ "$status" -eq 0 ]
+}
+
 @test "skillshare: uses sync --all --force flags" {
     run grep -q 'sync --all --force' "$LIB_FILE"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## 概要

skillshare CLI の供給に関わる 2 点を更新します。

1. `setup.sh` が参照する取得元 tag pin（`SKILLSHARE_VERSION`）を `v0.19.12` → **`v0.20.7`**。
2. 既存の opt-in SHA256 検証機構のデフォルトに **v0.20.7 の install.sh のハッシュを pin** し、**既定で検証を有効化**（supply-chain 防御）。

ローカルで `skillshare upgrade --cli` により実機を 0.20.7 へ上げたため、セットアップ側の pin を追従させたうえで、レビュー指摘を踏まえ供給元の内容一意性も担保します。

## コミット構成

| コミット | 内容 |
|---|---|
| `3beb612` | `SKILLSHARE_VERSION` を `v0.19.12` → `v0.20.7` |
| `6a5f235` | `SKILLSHARE_INSTALLER_SHA256` に v0.20.7 install.sh のハッシュを pin（検証を常時有効化） |
| `13c7cb2` | opt-out が空文字 env で効くよう `${var-...}`（コロンなし）へ修正＋回帰テスト追加（Copilot 指摘対応） |

## 背景・理由

- pin が `v0.19.12` のままだと `bash setup.sh skillshare --upgrade` で 0.20.7 が **巻き戻る** 不整合が発生する。
- tag pin だけでは `raw.githubusercontent.com` の内容一意性を保証できない（`git tag -f` による差し替えが即時反映）。SHA256 照合で内容を固定し、その弱点を塞ぐ。

## 方針

- **tag pin の方針は維持**（main 追従にはしない。供給元固定・再現性優先）。
- **SHA256 検証は既定で有効**（`SKILLSHARE_INSTALLER_SHA256` に v0.20.7 の install.sh ハッシュを pin）。env で空文字を明示すれば opt-out 可能（`${var-...}` 採用）。
- `SKILLSHARE_VERSION` 更新時は SHA256 も追従が必要な旨をコメントに明記。

## テスト計画

- [x] shfmt（`-d -i 4 -ln bash`）: 差分なし
- [x] shellcheck（`-x -s bash -e SC2154,SC1091,SC2034,SC2317`）: 変更ファイル指摘ゼロ
- [x] bats 全 **180 件 PASS**（タグ pin / SHA256 pin・コロンなしデフォルトの回帰テスト含む）
- [x] **E2E**: pin 値 == 実 install.sh のハッシュ一致（インストールを壊さない）
- [x] 展開セマンティクス実動作確認（unset→検証ON / 空文字 env→skip）
- [x] 並列レビュー（code-reviewer / security-reviewer / pr-test-analyzer）＋ Copilot 指摘対応済み
- [x] GitHub Actions CI 全チェック green（直近コミットで再走）