### PR TITLE
feat: dev環境セットアップに ccstatusline を統合

### DIFF
--- a/dotfiles/.claude/settings.json
+++ b/dotfiles/.claude/settings.json
@@ -361,5 +361,11 @@
   },
   "language": "日本語",
   "effortLevel": "high",
-  "autoMemoryEnabled": true
+  "autoMemoryEnabled": true,
+  "statusLine": {
+    "type": "command",
+    "command": "ccstatusline",
+    "padding": 0,
+    "refreshInterval": 10
+  }
 }

--- a/dotfiles/modules/claude-code.sh
+++ b/dotfiles/modules/claude-code.sh
@@ -379,6 +379,26 @@ setup_claude_code() {
     fi
 
     # =========================================
+    # ステータスライン (ccstatusline) のインストール
+    # =========================================
+    # NOTE: settings.json の statusLine が `ccstatusline` コマンドを呼ぶ。Claude Code 本体とは
+    #       独立した補助ツールのため、失敗しても致命的ではない（return せず警告に留める）。
+    if command -v ccstatusline >/dev/null 2>&1 && ! ((UPGRADE)); then
+        msg_info "ccstatusline は既にインストールされています。スキップします。"
+    elif ! command -v npm >/dev/null 2>&1; then
+        msg_warn "npm が見つからないため ccstatusline をスキップしました。"
+    else
+        msg_info "ステータスライン (ccstatusline) をインストールします..."
+        if ! run_cmd npm install -g ccstatusline@latest; then
+            msg_warn "ccstatusline のインストールに失敗しました（statusLine は表示されませんが Claude Code は利用可能です）。"
+        elif ((DRY_RUN)); then
+            msg_info "ccstatusline をインストール予定です（dry-run）。"
+        else
+            msg_success "ccstatusline のインストールが完了しました。"
+        fi
+    fi
+
+    # =========================================
     # 設定ファイルの配置
     # =========================================
     printf '\n'
@@ -537,6 +557,17 @@ uninstall_claude_code() {
         return 1
     }
     msg_success "Claude Code をアンインストールしました。"
+
+    # ステータスライン (ccstatusline) も併せて削除（補助ツールのため非致命）
+    if command -v npm >/dev/null 2>&1 && npm ls -g ccstatusline >/dev/null 2>&1; then
+        msg_info "ccstatusline をアンインストールします..."
+        if run_cmd npm uninstall -g ccstatusline; then
+            msg_success "ccstatusline をアンインストールしました。"
+        else
+            msg_warn "ccstatusline のアンインストールに失敗しました。"
+        fi
+    fi
+
     printf '%s\n' "NOTE: ~/.claude/ ディレクトリの空ディレクトリは削除されていません。不要な場合は手動で削除してください:"
     local cleanup_dirs="rules"
     local d


### PR DESCRIPTION
## 概要
新しい開発環境を dotfiles から構築した際に、Claude Code のステータスライン整形ツール [ccstatusline](https://github.com/sirmalloc/ccstatusline) が自動で導入・設定されるようにする。

これまでは `~/.claude/settings.json` に `statusLine` を手で書いても、新環境では ccstatusline 本体が入っておらず表示されなかった。本PRで **設定とツールが常にセットで入る** 形にする。

## 変更内容
### `dotfiles/modules/claude-code.sh`
- **install**: Claude Code 本体 (`@anthropic-ai/claude-code`) 導入の直後に `npm install -g ccstatusline@latest` を追加
  - 冪等（既導入ならスキップ）
  - `npm` が無ければスキップ
  - **失敗しても致命的にしない**（`return` せず `msg_warn` のみ）。補助ツールのため本体構築は継続
  - dry-run 対応
- **uninstall**: Claude Code 削除時に ccstatusline も併せて削除（対称性のため・非致命）

### `dotfiles/.claude/settings.json`
- `statusLine` 設定を追加（新環境の `~/.claude/settings.json` として配置される）
  ```json
  "statusLine": { "type": "command", "command": "ccstatusline", "padding": 0, "refreshInterval": 10 }
  ```

## 設計意図
`claude-code.sh` モジュールが「Claude 本体の導入」と「`.claude/settings.json` の配置」を一手に担っているため、ここに導入処理を足すことで、`statusLine` だけ書かれてコマンドが存在しない壊れ方を防ぐ。

```
setup.sh → claude-code モジュール選択
  → @anthropic-ai/claude-code 導入
  → ccstatusline 導入（NEW）
  → settings.json(statusLine入り) を ~/.claude へ配置
```

## 留意点
- claude-code モジュールは元々**任意選択**（`MODULE_DEFAULT=0`）。選択時のみ動作し、既存の挙動は変えない。
- バージョン方針: 構築時点の `@latest` を導入（＝各環境で最新を入れてその環境内で固定）。再現性を厳密にしたい場合は将来 `ccstatusline@<version>` への固定も可。
- 前提: node/npm（モジュールは元々 `MODULE_DEPS="node"`）。
- 安全性: ccstatusline は依存ゼロ・インストールフック無し・npm provenance(SLSA)付き。使用量ウィジェット使用時のみ OAuth トークンを読み、送信先は Anthropic 公式 (`api.anthropic.com`) のみ。

## テスト計画
- [x] `bash -n dotfiles/modules/claude-code.sh`（構文チェック）通過
- [x] `dotfiles/.claude/settings.json` が正当な JSON であることを確認
- [ ] `setup.sh` を dry-run（claude-code モジュール選択）し、ccstatusline 導入ステップが表示されること
- [ ] クリーン環境（devcontainer 等）で実際に setup を実行し、`ccstatusline` が導入され Claude 起動時にステータスラインが表示されること
- [ ] `npm` 不在環境でスキップ（警告のみ）され、本体構築が継続すること
- [ ] uninstall 実行で ccstatusline も削除されること